### PR TITLE
feat(infra): local dev Postgres via Compose (#2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,12 @@
 # Copy to `.env` for local development:
 #   cp .env.example .env
 #
-# Compose reads this file for variable substitution (CLI `--env-file`) and,
-# by default, mounts it into the db container via ENV_FILE (see compose.yaml).
+# Typical workflow: keep secrets in `.env`. Compose interpolates variables from
+# the project directory `.env` automatically; `compose.yaml` also passes that
+# file into the db container via `env_file: ${ENV_FILE:-.env}` (see compose.yaml).
+#
+# `scripts/verify-infra.sh` sets `ENV_FILE` to this file so checks run against a
+# fixed template without overwriting your `.env`.
 
 POSTGRES_USER=pfa
 POSTGRES_PASSWORD=pfa_dev_password_change_me

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,17 @@
+# Copy to `.env` for local development:
+#   cp .env.example .env
+#
+# Compose reads this file for variable substitution (CLI `--env-file`) and,
+# by default, mounts it into the db container via ENV_FILE (see compose.yaml).
+
+POSTGRES_USER=pfa
+POSTGRES_PASSWORD=pfa_dev_password_change_me
+POSTGRES_DB=pfa
+POSTGRES_PORT=5432
+
+# Bind-mount: host directory for raw statement uploads (durable local dev path).
+RAW_STATEMENTS_HOST_PATH=./data/raw-statements
+RAW_STATEMENTS_CONTAINER_PATH=/data/raw-statements
+
+# Backend (runs on host): matches POSTGRES_* and published port above.
+DATABASE_URL=postgresql://pfa:pfa_dev_password_change_me@127.0.0.1:5432/pfa

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local bind mounts (raw uploads); Postgres data uses the named Docker volume `pgdata`.
+data/
+
 # Secrets — never commit
 .env
 .env.local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: verify-infra
+
+verify-infra:
+	./scripts/verify-infra.sh

--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ From the repository root:
 
    Optional explicit file: `docker compose --env-file .env up -d`.
 
+   Postgres is published on **`127.0.0.1:${POSTGRES_PORT}`** only (not all interfaces); change [`compose.yaml`](compose.yaml) if you intentionally need LAN access.
+
    Wait until Postgres is ready: `docker compose ps` should show **`db`** as **`healthy`**, or use `docker compose up -d --wait` if your Compose version supports it.
 
 4. From the host, connect using **`DATABASE_URL`** in `.env` (see `.env.example`; defaults use `127.0.0.1` and **`POSTGRES_PORT`**).

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ From the repository root:
 
 4. From the host, connect using **`DATABASE_URL`** in `.env` (see `.env.example`; defaults use `127.0.0.1` and **`POSTGRES_PORT`**).
 
-5. Run the automated checks (compose config, readiness, `SELECT 1`, persistence across **`db` restart`, raw mount):
+5. Run the automated checks (compose config, readiness, `SELECT 1`, persistence across **`db` restart**, raw mount):
 
    ```bash
    make verify-infra

--- a/README.md
+++ b/README.md
@@ -6,21 +6,23 @@ Self-hosted personal finance stack: ingest bank and credit card statements (CSV 
 
 **Implementation slices (vertical, end-to-end):**
 
-| # | Topic | Issue |
-|---:|---|---|
-| 0 | Local dev infra (Docker Compose, Postgres, volumes, wiring) | [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2) |
-| 1 | Auth + localhost-only app shell | [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) |
-| 2 | Ledger foundation (institutions, accounts, categories) | [#4](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/4) |
-| 3 | Async jobs + step-level status UI | [#5](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/5) |
-| 4 | CSV ingestion + dedupe | [#6](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/6) |
-| 5 | Raw file storage + hash idempotency + purge | [#7](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/7) |
-| 6 | Budgeting (envelope monthly + suggest + status) | [#8](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/8) |
-| 7 | Rules-first categorization + rule proposals | [#9](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/9) |
-| 8 | Recurring detection + UI | [#10](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/10) |
-| 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) |
-| 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) |
-| 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) |
-| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) |
+| # | Topic | Issue | Status |
+|---:|---|---|---|
+| 0 | Local dev infra (Docker Compose, Postgres, volumes, wiring) | [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2) | **Shipped** |
+| 1 | Auth + localhost-only app shell | [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) | Planned |
+| 2 | Ledger foundation (institutions, accounts, categories) | [#4](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/4) | Planned |
+| 3 | Async jobs + step-level status UI | [#5](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/5) | Planned |
+| 4 | CSV ingestion + dedupe | [#6](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/6) | Planned |
+| 5 | Raw file storage + hash idempotency + purge | [#7](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/7) | Planned |
+| 6 | Budgeting (envelope monthly + suggest + status) | [#8](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/8) | Planned |
+| 7 | Rules-first categorization + rule proposals | [#9](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/9) | Planned |
+| 8 | Recurring detection + UI | [#10](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/10) | Planned |
+| 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) | Planned |
+| 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) | Planned |
+| 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) | Planned |
+| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) | Planned |
+
+**Slice 0** in this repo: [`compose.yaml`](compose.yaml), [`.env.example`](.env.example), [`scripts/verify-infra.sh`](scripts/verify-infra.sh), [`Makefile`](Makefile) (`verify-infra`). PR: [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15).
 
 ---
 
@@ -60,7 +62,7 @@ The MVP is **single-user, self-hosted**, optimized for a trustworthy ledger and 
 
 ### Definition of done (MVP demo)
 
-You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2)), log in, upload **CSV**, watch ingestion complete with step status, see transactions and charts, set **monthly budgets** with suggestions, see **recurring** and **anomaly** lists, and chat with the agent using tools—without duplicate transactions on retry/re-upload.
+You can: bring up **Postgres locally** ([Getting started](#getting-started)), then run the full stack once later slices land—log in, upload **CSV**, watch ingestion complete with step status, see transactions and charts, set **monthly budgets** with suggestions, see **recurring** and **anomaly** lists, and chat with the agent using tools—without duplicate transactions on retry/re-upload.
 
 ---
 
@@ -68,7 +70,7 @@ You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarl
 
 - **Frontend**: Vite + React + TypeScript; dedicated **Upload** surface plus **Chat**; charts for cashflow, categories, budgets, recurring, anomalies.
 - **Backend**: single service hosting HTTP API, **Postgres-backed job queue**, ingestion pipeline, analytics queries, **LLM client abstraction** (pluggable providers), embedded **tool** layer, **LangSmith** hooks.
-- **Data**: PostgreSQL as system of record; **raw statement files** on a mounted volume/path suitable for Docker/local dev.
+- **Data**: PostgreSQL as system of record; **raw statement files** on a mounted path. **Local dev today:** [`compose.yaml`](compose.yaml) defines service **`db`** (PostgreSQL 16), a **named volume** `pgdata` for database files, and a **bind-mounted** host directory for raw uploads (`./data/raw-statements` by default, gitignored).
 
 ---
 
@@ -78,42 +80,46 @@ You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarl
 
 Prerequisites: [Docker](https://docs.docker.com/get-docker/) with Compose v2.
 
-1. Copy env template and adjust passwords if you like:
+From the repository root:
+
+1. Copy the env template and edit secrets if you want non-default passwords:
 
    ```bash
    cp .env.example .env
    ```
 
-2. Ensure the raw-statement bind-mount directory exists (ignored by git):
+2. Create the raw-statement bind-mount directory (gitignored; Compose also creates it when missing on many setups):
 
    ```bash
    mkdir -p data/raw-statements
    ```
 
-3. Start Postgres (named volume `pgdata` keeps database files across restarts):
+3. Start Postgres. Compose loads **`.env`** from this directory for variable substitution; the **`db`** service also reads that file so credentials stay in sync:
 
    ```bash
-   docker compose --env-file .env up -d
+   docker compose up -d
    ```
 
-   Compose waits on the service healthcheck when your CLI supports `up --wait`; otherwise wait until `docker compose ps` shows `healthy` for `db`.
+   Optional explicit file: `docker compose --env-file .env up -d`.
 
-4. Connection string for a backend on the host is **`DATABASE_URL`** in `.env` (defaults to `127.0.0.1` and `POSTGRES_PORT`).
+   Wait until Postgres is ready: `docker compose ps` should show **`db`** as **`healthy`**, or use `docker compose up -d --wait` if your Compose version supports it.
 
-5. Verify infra (config, connectivity, persistence across `db` restart, raw mount):
+4. From the host, connect using **`DATABASE_URL`** in `.env` (see `.env.example`; defaults use `127.0.0.1` and **`POSTGRES_PORT`**).
+
+5. Run the automated checks (compose config, readiness, `SELECT 1`, persistence across **`db` restart`, raw mount):
 
    ```bash
    make verify-infra
    ```
 
-   Optional: `make verify-infra` runs `./scripts/verify-infra.sh`, which uses `.env.example` and ends with `docker compose down` (volumes kept). To remove the Postgres volume too: `./scripts/verify-infra.sh --teardown-volumes`.
+   This runs [`scripts/verify-infra.sh`](scripts/verify-infra.sh) against **`.env.example`**, then **`docker compose down`** without `-v` so the **`pgdata`** volume remains. To drop volumes after the run: `./scripts/verify-infra.sh --teardown-volumes`.
 
 **Teardown**
 
-- Stop containers but **keep** database volume: `docker compose down`
-- Stop and **delete** Postgres data volume: `docker compose down -v`
+- Stop containers, **keep** Postgres data: `docker compose down`
+- Stop and **delete** the **`pgdata`** volume: `docker compose down -v`
 
-Until the rest of the app lands, continue with the **vertical slices** in order (next: [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) auth + shell).
+**Next slice:** [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) (auth + localhost-only app shell).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,46 @@ You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarl
 
 ## Getting started
 
-Until the repo contains the full app again, follow the **vertical slices** in order (especially **#2** for Compose + Postgres + volumes). When `docker compose` and env templates land, this section should be updated with exact commands—tracked in [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2).
+### Local database (slice [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2))
+
+Prerequisites: [Docker](https://docs.docker.com/get-docker/) with Compose v2.
+
+1. Copy env template and adjust passwords if you like:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Ensure the raw-statement bind-mount directory exists (ignored by git):
+
+   ```bash
+   mkdir -p data/raw-statements
+   ```
+
+3. Start Postgres (named volume `pgdata` keeps database files across restarts):
+
+   ```bash
+   docker compose --env-file .env up -d
+   ```
+
+   Compose waits on the service healthcheck when your CLI supports `up --wait`; otherwise wait until `docker compose ps` shows `healthy` for `db`.
+
+4. Connection string for a backend on the host is **`DATABASE_URL`** in `.env` (defaults to `127.0.0.1` and `POSTGRES_PORT`).
+
+5. Verify infra (config, connectivity, persistence across `db` restart, raw mount):
+
+   ```bash
+   make verify-infra
+   ```
+
+   Optional: `make verify-infra` runs `./scripts/verify-infra.sh`, which uses `.env.example` and ends with `docker compose down` (volumes kept). To remove the Postgres volume too: `./scripts/verify-infra.sh --teardown-volumes`.
+
+**Teardown**
+
+- Stop containers but **keep** database volume: `docker compose down`
+- Stop and **delete** Postgres data volume: `docker compose down -v`
+
+Until the rest of the app lands, continue with the **vertical slices** in order (next: [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) auth + shell).
 
 ---
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,26 @@
+name: personal-financial-analyst
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - ${ENV_FILE:-.env}
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-pfa}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pfa_dev_password_change_me}
+      POSTGRES_DB: ${POSTGRES_DB:-pfa}
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}:${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
+      interval: 3s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+
+volumes:
+  pgdata:

--- a/compose.yaml
+++ b/compose.yaml
@@ -11,7 +11,8 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pfa_dev_password_change_me}
       POSTGRES_DB: ${POSTGRES_DB:-pfa}
     ports:
-      - "${POSTGRES_PORT:-5432}:5432"
+      # Bind loopback only by default (matches localhost-first posture in README).
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
     volumes:
       - pgdata:/var/lib/postgresql/data
       - ${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}:${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+# Verifies issue #2 acceptance: compose config, Postgres readiness, connectivity,
+# and data persistence across container restart (named volume).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ENV_EXAMPLE="${ROOT}/.env.example"
+COMPOSE_FILE="${ROOT}/compose.yaml"
+TEARDOWN_VOLUMES=false
+for arg in "$@"; do
+  case "$arg" in
+    --teardown-volumes) TEARDOWN_VOLUMES=true ;;
+    -h|--help)
+      echo "Usage: $0 [--teardown-volumes]"
+      echo "  --teardown-volumes  Run 'docker compose down -v' after checks (removes pg volume)."
+      exit 0
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found in PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "error: missing .env.example at $ENV_EXAMPLE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "error: missing compose.yaml at $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a && source "$ENV_EXAMPLE" && set +a
+
+export ENV_FILE="$ENV_EXAMPLE"
+DC=(docker compose --env-file "$ENV_EXAMPLE" -f "$COMPOSE_FILE")
+
+mkdir -p "${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}"
+
+echo "==> compose config"
+"${DC[@]}" config -q
+
+wait_for_db() {
+  local attempts=60
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if "${DC[@]}" exec -T db pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "error: Postgres did not become ready within ${attempts}s" >&2
+  return 1
+}
+
+echo "==> compose up"
+if "${DC[@]}" up -d --wait 2>/dev/null; then
+  :
+else
+  "${DC[@]}" up -d
+  wait_for_db
+fi
+
+echo "==> connectivity (SELECT 1)"
+"${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null
+
+echo "==> persistence marker + container restart"
+"${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "
+CREATE TABLE IF NOT EXISTS _pfa_infra_issue2 (k text PRIMARY KEY, v text NOT NULL);
+INSERT INTO _pfa_infra_issue2 (k, v) VALUES ('marker', 'issue2-persist')
+  ON CONFLICT (k) DO UPDATE SET v = EXCLUDED.v;
+" >/dev/null
+
+"${DC[@]}" restart db >/dev/null
+
+if "${DC[@]}" up -d --wait 2>/dev/null; then
+  :
+else
+  wait_for_db
+fi
+
+marker="$("${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -At -c \
+  "SELECT v FROM _pfa_infra_issue2 WHERE k = 'marker';")"
+marker="$(echo "$marker" | tr -d '\r')"
+if [[ "$marker" != "issue2-persist" ]]; then
+  echo "error: expected persistence marker 'issue2-persist', got '${marker:-}'" >&2
+  exit 1
+fi
+
+echo "==> raw statements mount visible in container"
+"${DC[@]}" exec -T db sh -c "test -d '${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}'"
+
+echo "All infra checks passed."
+
+if [[ "$TEARDOWN_VOLUMES" == true ]]; then
+  echo "==> docker compose down -v"
+  "${DC[@]}" down -v
+else
+  echo "==> docker compose down (volumes retained)"
+  "${DC[@]}" down
+fi

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -41,6 +41,7 @@ set -a && source "$ENV_EXAMPLE" && set +a
 export ENV_FILE="$ENV_EXAMPLE"
 DC=(docker compose --env-file "$ENV_EXAMPLE" -f "$COMPOSE_FILE")
 
+# Track whether this script started the db (so we never tear down a pre-existing stack).
 STACK_STARTED=0
 cleanup() {
   local ec=$?
@@ -76,6 +77,13 @@ wait_for_db() {
   return 1
 }
 
+# Detect whether the db container was already running before this script touched it.
+# If it was, we leave it running on exit regardless of --teardown-volumes.
+DB_WAS_RUNNING=0
+if [[ -n "$("${DC[@]}" ps -q db 2>/dev/null)" ]]; then
+  DB_WAS_RUNNING=1
+fi
+
 echo "==> compose up"
 if "${DC[@]}" up -d --wait 2>/dev/null; then
   :
@@ -83,7 +91,10 @@ else
   "${DC[@]}" up -d
   wait_for_db
 fi
-STACK_STARTED=1
+# Only mark the stack for teardown if this script was the one that started it.
+if [[ "$DB_WAS_RUNNING" == 0 ]]; then
+  STACK_STARTED=1
+fi
 
 echo "==> connectivity (SELECT 1)"
 "${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -46,7 +46,7 @@ STACK_STARTED=0
 cleanup() {
   local ec=$?
   trap - EXIT
-  if [[ "$STACK_STARTED" == 1 ]]; then
+  if [[ "$STACK_STARTED" -eq 1 ]]; then
     if [[ "$TEARDOWN_VOLUMES" == true ]]; then
       echo "==> docker compose down -v"
       "${DC[@]}" down -v || true
@@ -92,7 +92,7 @@ else
   wait_for_db
 fi
 # Only mark the stack for teardown if this script was the one that started it.
-if [[ "$DB_WAS_RUNNING" == 0 ]]; then
+if [[ "$DB_WAS_RUNNING" -eq 0 ]]; then
   STACK_STARTED=1
 fi
 

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -41,6 +41,23 @@ set -a && source "$ENV_EXAMPLE" && set +a
 export ENV_FILE="$ENV_EXAMPLE"
 DC=(docker compose --env-file "$ENV_EXAMPLE" -f "$COMPOSE_FILE")
 
+STACK_STARTED=0
+cleanup() {
+  local ec=$?
+  trap - EXIT
+  if [[ "$STACK_STARTED" == 1 ]]; then
+    if [[ "$TEARDOWN_VOLUMES" == true ]]; then
+      echo "==> docker compose down -v"
+      "${DC[@]}" down -v || true
+    else
+      echo "==> docker compose down (volumes retained)"
+      "${DC[@]}" down || true
+    fi
+  fi
+  exit "$ec"
+}
+trap cleanup EXIT
+
 mkdir -p "${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}"
 
 echo "==> compose config"
@@ -66,6 +83,7 @@ else
   "${DC[@]}" up -d
   wait_for_db
 fi
+STACK_STARTED=1
 
 echo "==> connectivity (SELECT 1)"
 "${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null
@@ -97,11 +115,3 @@ echo "==> raw statements mount visible in container"
 "${DC[@]}" exec -T db sh -c "test -d '${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}'"
 
 echo "All infra checks passed."
-
-if [[ "$TEARDOWN_VOLUMES" == true ]]; then
-  echo "==> docker compose down -v"
-  "${DC[@]}" down -v
-else
-  echo "==> docker compose down (volumes retained)"
-  "${DC[@]}" down
-fi


### PR DESCRIPTION
## Summary

Implements [Slice 0 / issue #2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2): Docker Compose Postgres with durable volumes, raw-statement bind mount, documented env wiring, healthcheck, and automated verification.

## Changes

- `compose.yaml`: Postgres 16 Alpine, named volume `pgdata`, bind mount for raw statements, `pg_isready` healthcheck
- `.env.example`: `POSTGRES_*`, `DATABASE_URL`, raw path vars (copy to `.env`)
- `scripts/verify-infra.sh` + `make verify-infra`: config, readiness, `SELECT 1`, persistence across `db` restart, mount visibility
- README Getting started and teardown notes; `.gitignore` for `data/`

## How to verify

```bash
make verify-infra
```

Closes #2

Made with [Cursor](https://cursor.com)