### PR TITLE
feat(infra): Docker Compose Postgres on master (slice 0 / #2)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy to `.env` for local development:
+#   cp .env.example .env
+#
+# Typical workflow: keep secrets in `.env`. Compose interpolates variables from
+# the project directory `.env` automatically; `compose.yaml` also passes that
+# file into the db container via `env_file: ${ENV_FILE:-.env}` (see compose.yaml).
+#
+# `scripts/verify-infra.sh` sets `ENV_FILE` to this file so checks run against a
+# fixed template without overwriting your `.env`.
+
+POSTGRES_USER=pfa
+POSTGRES_PASSWORD=pfa_dev_password_change_me
+POSTGRES_DB=pfa
+POSTGRES_PORT=5432
+
+# Bind-mount: host directory for raw statement uploads (durable local dev path).
+RAW_STATEMENTS_HOST_PATH=./data/raw-statements
+RAW_STATEMENTS_CONTAINER_PATH=/data/raw-statements
+
+# Backend (runs on host): matches POSTGRES_* and published port above.
+DATABASE_URL=postgresql://pfa:pfa_dev_password_change_me@127.0.0.1:5432/pfa

--- a/.env.example
+++ b/.env.example
@@ -17,5 +17,6 @@ POSTGRES_PORT=5432
 RAW_STATEMENTS_HOST_PATH=./data/raw-statements
 RAW_STATEMENTS_CONTAINER_PATH=/data/raw-statements
 
-# Backend (runs on host): matches POSTGRES_* and published port above.
+# Backend (runs on host): user/password/database match POSTGRES_* above.
+# The host port in this URL must match POSTGRES_PORT (Compose binds 127.0.0.1:<POSTGRES_PORT>→5432).
 DATABASE_URL=postgresql://pfa:pfa_dev_password_change_me@127.0.0.1:5432/pfa

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local bind mounts (raw uploads); Postgres data uses the named Docker volume `pgdata`.
+data/
+
 # Secrets — never commit
 .env
 .env.local

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: verify-infra
+
+verify-infra:
+	./scripts/verify-infra.sh

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Self-hosted personal finance stack: ingest bank and credit card statements (CSV and targeted PDFs), normalize them into **PostgreSQL**, and use a **backend-run AI agent** with an **MCP-shaped tool layer** for budgeting, charts, recurring spend, anomalies, and chat grounded in your ledger.
 
-**Product spec:** [PRD #1 — Personal Finance MCP server + agent-driven UI (self-hosted MVP)](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/1)
+**Product spec:** [docs/PRD.md](docs/PRD.md) (canonical copy) · [Issue #1 — PRD discussion](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/1)
 
 **Implementation slices (vertical, end-to-end):**
 
@@ -22,7 +22,7 @@ Self-hosted personal finance stack: ingest bank and credit card statements (CSV 
 | 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) | Planned |
 | 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) | Planned |
 
-**Slice 0** in this repo: [`compose.yaml`](compose.yaml), [`.env.example`](.env.example), [`scripts/verify-infra.sh`](scripts/verify-infra.sh), [`Makefile`](Makefile) (`verify-infra`). PR: [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15).
+**Slice 0** in this repo: [`compose.yaml`](compose.yaml), [`.env.example`](.env.example), [`scripts/verify-infra.sh`](scripts/verify-infra.sh), [`Makefile`](Makefile) (`verify-infra`). Same stack merged to `main` in [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15); **this PR fast-forwards `master` to include slice 0 for [issue #2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2).**
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ From the repository root:
    mkdir -p data/raw-statements
    ```
 
-3. Start Postgres. Compose loads **`.env`** from this directory for variable substitution; the **`db`** service also reads that file so credentials stay in sync:
+3. Start Postgres. Compose loads **`.env`** from this directory for variable substitution; the **`db`** service also reads that file so credentials stay in sync. The Compose **project name** defaults to this folder’s name (no fixed `name:` in [`compose.yaml`](compose.yaml)), so separate clones keep distinct containers/volumes. Override with [`docker compose --project-name …`](https://docs.docker.com/compose/how-tos/project-name/) if needed.
 
    ```bash
    docker compose up -d
@@ -114,7 +114,7 @@ From the repository root:
    make verify-infra
    ```
 
-   This runs [`scripts/verify-infra.sh`](scripts/verify-infra.sh) against **`.env.example`**, then **`docker compose down`** without `-v` so the **`pgdata`** volume remains. To drop volumes after the run: `./scripts/verify-infra.sh --teardown-volumes`.
+   This runs [`scripts/verify-infra.sh`](scripts/verify-infra.sh) against **`.env.example`**. **Teardown:** if **`db` was not running** when the script started, it finishes with **`docker compose down`** (no `-v`, **`pgdata`** kept). If **`db` was already up**, the script **leaves your stack running**—only inspects it—so you are not surprised by missing teardown. To drop volumes when the script does tear down: `./scripts/verify-infra.sh --teardown-volumes`.
 
 **Teardown**
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,23 @@ Self-hosted personal finance stack: ingest bank and credit card statements (CSV 
 
 **Implementation slices (vertical, end-to-end):**
 
-| # | Topic | Issue |
-|---:|---|---|
-| 0 | Local dev infra (Docker Compose, Postgres, volumes, wiring) | [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2) |
-| 1 | Auth + localhost-only app shell | [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) |
-| 2 | Ledger foundation (institutions, accounts, categories) | [#4](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/4) |
-| 3 | Async jobs + step-level status UI | [#5](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/5) |
-| 4 | CSV ingestion + dedupe | [#6](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/6) |
-| 5 | Raw file storage + hash idempotency + purge | [#7](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/7) |
-| 6 | Budgeting (envelope monthly + suggest + status) | [#8](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/8) |
-| 7 | Rules-first categorization + rule proposals | [#9](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/9) |
-| 8 | Recurring detection + UI | [#10](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/10) |
-| 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) |
-| 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) |
-| 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) |
-| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) |
+| # | Topic | Issue | Status |
+|---:|---|---|---|
+| 0 | Local dev infra (Docker Compose, Postgres, volumes, wiring) | [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2) | **Shipped** |
+| 1 | Auth + localhost-only app shell | [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) | Planned |
+| 2 | Ledger foundation (institutions, accounts, categories) | [#4](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/4) | Planned |
+| 3 | Async jobs + step-level status UI | [#5](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/5) | Planned |
+| 4 | CSV ingestion + dedupe | [#6](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/6) | Planned |
+| 5 | Raw file storage + hash idempotency + purge | [#7](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/7) | Planned |
+| 6 | Budgeting (envelope monthly + suggest + status) | [#8](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/8) | Planned |
+| 7 | Rules-first categorization + rule proposals | [#9](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/9) | Planned |
+| 8 | Recurring detection + UI | [#10](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/10) | Planned |
+| 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) | Planned |
+| 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) | Planned |
+| 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) | Planned |
+| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) | Planned |
+
+**Slice 0** in this repo: [`compose.yaml`](compose.yaml), [`.env.example`](.env.example), [`scripts/verify-infra.sh`](scripts/verify-infra.sh), [`Makefile`](Makefile) (`verify-infra`). PR: [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15).
 
 ---
 
@@ -60,7 +62,7 @@ The MVP is **single-user, self-hosted**, optimized for a trustworthy ledger and 
 
 ### Definition of done (MVP demo)
 
-You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2)), log in, upload **CSV**, watch ingestion complete with step status, see transactions and charts, set **monthly budgets** with suggestions, see **recurring** and **anomaly** lists, and chat with the agent using tools—without duplicate transactions on retry/re-upload.
+You can: bring up **Postgres locally** ([Getting started](#getting-started)), then run the full stack once later slices land—log in, upload **CSV**, watch ingestion complete with step status, see transactions and charts, set **monthly budgets** with suggestions, see **recurring** and **anomaly** lists, and chat with the agent using tools—without duplicate transactions on retry/re-upload.
 
 ---
 
@@ -68,13 +70,58 @@ You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarl
 
 - **Frontend**: Vite + React + TypeScript; dedicated **Upload** surface plus **Chat**; charts for cashflow, categories, budgets, recurring, anomalies.
 - **Backend**: single service hosting HTTP API, **Postgres-backed job queue**, ingestion pipeline, analytics queries, **LLM client abstraction** (pluggable providers), embedded **tool** layer, **LangSmith** hooks.
-- **Data**: PostgreSQL as system of record; **raw statement files** on a mounted volume/path suitable for Docker/local dev.
+- **Data**: PostgreSQL as system of record; **raw statement files** on a mounted path. **Local dev today:** [`compose.yaml`](compose.yaml) defines service **`db`** (PostgreSQL 16), a **named volume** `pgdata` for database files, and a **bind-mounted** host directory for raw uploads (`./data/raw-statements` by default, gitignored).
 
 ---
 
 ## Getting started
 
-Until the repo contains the full app again, follow the **vertical slices** in order (especially **#2** for Compose + Postgres + volumes). When `docker compose` and env templates land, this section should be updated with exact commands—tracked in [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2).
+### Local database (slice [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2))
+
+Prerequisites: [Docker](https://docs.docker.com/get-docker/) with Compose v2.
+
+From the repository root:
+
+1. Copy the env template and edit secrets if you want non-default passwords:
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. Create the raw-statement bind-mount directory (gitignored; Compose also creates it when missing on many setups):
+
+   ```bash
+   mkdir -p data/raw-statements
+   ```
+
+3. Start Postgres. Compose loads **`.env`** from this directory for variable substitution; the **`db`** service also reads that file so credentials stay in sync:
+
+   ```bash
+   docker compose up -d
+   ```
+
+   Optional explicit file: `docker compose --env-file .env up -d`.
+
+   Postgres is published on **`127.0.0.1:${POSTGRES_PORT}`** only (not all interfaces); change [`compose.yaml`](compose.yaml) if you intentionally need LAN access.
+
+   Wait until Postgres is ready: `docker compose ps` should show **`db`** as **`healthy`**, or use `docker compose up -d --wait` if your Compose version supports it.
+
+4. From the host, connect using **`DATABASE_URL`** in `.env` (see `.env.example`; defaults use `127.0.0.1` and **`POSTGRES_PORT`**).
+
+5. Run the automated checks (compose config, readiness, `SELECT 1`, persistence across **`db` restart**, raw mount):
+
+   ```bash
+   make verify-infra
+   ```
+
+   This runs [`scripts/verify-infra.sh`](scripts/verify-infra.sh) against **`.env.example`**, then **`docker compose down`** without `-v` so the **`pgdata`** volume remains. To drop volumes after the run: `./scripts/verify-infra.sh --teardown-volumes`.
+
+**Teardown**
+
+- Stop containers, **keep** Postgres data: `docker compose down`
+- Stop and **delete** the **`pgdata`** volume: `docker compose down -v`
+
+**Next slice:** [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) (auth + localhost-only app shell).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,100 @@
+# Personal Financial Analyst
+
+Self-hosted personal finance stack: ingest bank and credit card statements (CSV and targeted PDFs), normalize them into **PostgreSQL**, and use a **backend-run AI agent** with an **MCP-shaped tool layer** for budgeting, charts, recurring spend, anomalies, and chat grounded in your ledger.
+
+**Product spec:** [PRD #1 — Personal Finance MCP server + agent-driven UI (self-hosted MVP)](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/1)
+
+**Implementation slices (vertical, end-to-end):**
+
+| # | Topic | Issue |
+|---:|---|---|
+| 0 | Local dev infra (Docker Compose, Postgres, volumes, wiring) | [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2) |
+| 1 | Auth + localhost-only app shell | [#3](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/3) |
+| 2 | Ledger foundation (institutions, accounts, categories) | [#4](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/4) |
+| 3 | Async jobs + step-level status UI | [#5](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/5) |
+| 4 | CSV ingestion + dedupe | [#6](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/6) |
+| 5 | Raw file storage + hash idempotency + purge | [#7](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/7) |
+| 6 | Budgeting (envelope monthly + suggest + status) | [#8](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/8) |
+| 7 | Rules-first categorization + rule proposals | [#9](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/9) |
+| 8 | Recurring detection + UI | [#10](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/10) |
+| 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) |
+| 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) |
+| 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) |
+| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) |
+
+---
+
+## MVP (what you get first)
+
+The MVP is **single-user, self-hosted**, optimized for a trustworthy ledger and a budgeting-first UI—not for multi-tenant SaaS.
+
+### Core capabilities
+
+- **Ingestion**
+  - **CSV** statements end-to-end: upload → async job → normalized transactions in Postgres.
+  - **One targeted credit card PDF** format (after a sample statement is agreed for parser tests); generic “any PDF” is explicitly later work.
+  - **Async jobs** backed by Postgres, with **step-level status** and counts; UI **polls** job progress (no streaming of job steps in MVP).
+  - **Statement-level** idempotency (content hash) and **transaction-level** dedupe (deterministic fingerprint + uniqueness).
+  - **Raw files** on disk with DB metadata; **soft-delete** and **permanent purge** (DB + files).
+
+- **Ledger & accounts**
+  - Institutions, accounts, **account aliases**, categories with **stable internal ids** (default taxonomy + user customization).
+
+- **Budgeting & analytics**
+  - **Envelope-style monthly budgets** per category, **month-to-date** views with simple **projection**, and **suggest from history** (aggregate-based, no LLM required).
+  - Cashflow and category views over time.
+  - **Recurring** charges: same merchant + similar amount, **monthly** cadence, **≥3** occurrences (deterministic).
+  - **Anomalies**: deterministic signals + simple robust stats; optional agent **explanations** after detection.
+
+- **Agent & tools**
+  - **Backend-run** agent; tools are **MCP-shaped** but **embedded in the backend** (not a separate MCP process for MVP).
+  - **High-level read tools** plus a **restricted read-only SQL** escape hatch for development and deep questions.
+  - **Streaming chat** in the UI.
+  - **Confirm-before-write** for any mutating tool path.
+  - **Privacy default**: aggregates to the model by default; **line-item context only on explicit drilldown**.
+  - **LangSmith** for tracing agent and tool calls.
+
+- **Security posture (MVP)**
+  - **Password login** + session cookie.
+  - **Localhost-only** binding by default; exposing beyond localhost is a deliberate later step (e.g. reverse proxy + TLS).
+
+### Definition of done (MVP demo)
+
+You can: run the stack locally (see slice [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2)), log in, upload **CSV**, watch ingestion complete with step status, see transactions and charts, set **monthly budgets** with suggestions, see **recurring** and **anomaly** lists, and chat with the agent using tools—without duplicate transactions on retry/re-upload.
+
+---
+
+## Architecture (conceptual)
+
+- **Frontend**: Vite + React + TypeScript; dedicated **Upload** surface plus **Chat**; charts for cashflow, categories, budgets, recurring, anomalies.
+- **Backend**: single service hosting HTTP API, **Postgres-backed job queue**, ingestion pipeline, analytics queries, **LLM client abstraction** (pluggable providers), embedded **tool** layer, **LangSmith** hooks.
+- **Data**: PostgreSQL as system of record; **raw statement files** on a mounted volume/path suitable for Docker/local dev.
+
+---
+
+## Getting started
+
+Until the repo contains the full app again, follow the **vertical slices** in order (especially **#2** for Compose + Postgres + volumes). When `docker compose` and env templates land, this section should be updated with exact commands—tracked in [#2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2).
+
+---
+
+## Future features (post-MVP)
+
+These are **explicitly out of scope** for the MVP PRD or natural next steps after it:
+
+- **Multi-tenant SaaS**: billing, orgs, enterprise SSO, row-level security hardening, abuse controls.
+- **Bank linking**: Plaid / open banking / institution APIs instead of file upload.
+- **Broad PDF support**: institution-agnostic PDF parsing beyond the first targeted card format; richer OCR/table pipelines as needed.
+- **Real-time job streaming**: SSE/WebSocket for ingestion step updates (MVP uses polling).
+- **Full observability stack**: metrics/tracing/logging beyond step-level job records + LangSmith.
+- **Stricter production exposure**: HTTPS reverse proxy, tighter CSRF/CORS, rate limits, and possibly **removing or locking down** the read-only SQL tool when not on localhost.
+- **Advanced budgeting**: rollovers, multi-month envelopes, goals/debt snowball, scenario planning.
+- **Richer recurring & anomaly models**: weekly/annual cadences, merchant clustering across name variants, more sophisticated stats/ML—still with explainable UI.
+- **Standalone MCP server**: same tool schemas exposed over stdio/HTTP for external agent runtimes (today: embedded for speed of iteration).
+- **BYOK / per-user provider keys** in UI, encrypted at rest (single-user MVP can start with `.env`).
+
+---
+
+## Disclaimer
+
+This project helps you **organize and analyze your own data**. It is **not** financial, legal, or tax advice. You are responsible for securing your machine, backups, and any keys (LLM, LangSmith, database).

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,27 @@
+name: personal-financial-analyst
+
+services:
+  db:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    env_file:
+      - ${ENV_FILE:-.env}
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-pfa}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-pfa_dev_password_change_me}
+      POSTGRES_DB: ${POSTGRES_DB:-pfa}
+    ports:
+      # Bind loopback only by default (matches localhost-first posture in README).
+      - "127.0.0.1:${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}:${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U \"$$POSTGRES_USER\" -d \"$$POSTGRES_DB\""]
+      interval: 3s
+      timeout: 5s
+      retries: 15
+      start_period: 10s
+
+volumes:
+  pgdata:

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,5 +1,3 @@
-name: personal-financial-analyst
-
 services:
   db:
     image: postgres:16-alpine

--- a/docs/PRD.md
+++ b/docs/PRD.md
@@ -1,0 +1,158 @@
+# PRD: Personal Finance MCP server + agent-driven UI (self-hosted MVP)
+
+Canonical copy of [GitHub Issue #1](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/1). Prefer discussing changes in that issue; update this document when the PRD is revised.
+
+---
+
+## Problem Statement
+
+I want a single-user, self-hosted personal finance system that can ingest bank and credit card statements (CSV and selected PDF formats), normalize them into a PostgreSQL ledger, and expose structured tools to an AI agent so I can get accurate budgeting, analysis, and conversational insights without manually wrangling spreadsheets.
+
+Today, statement data is fragmented across institutions and formats. Manual tracking is time-consuming, error-prone, and hard to keep up to date. Generic “chat with your finances” tools either can’t ingest reliably, don’t provide trustworthy normalization/deduplication, or lack actionable workflows (budgets, recurring, anomalies) that respect privacy.
+
+## Solution
+
+Build a self-hosted web app with a backend-run AI agent and an embedded MCP-shaped tool layer.
+
+Users can upload statements (CSV + targeted credit card PDF first). Uploads are processed asynchronously into a canonical transaction ledger in Postgres with strong deduplication. The UI provides a budgeting-first experience (monthly envelope budgets) plus charts and chat. The agent uses structured tools to answer questions, generate analyses, and propose changes, but must request confirmation before any write.
+
+The system defaults to privacy-preserving behavior: send aggregates to the LLM provider by default and only send minimal line-item details on explicit user drilldown. LangSmith is used for tracing agent/tool calls.
+
+## User Stories
+
+1. As a single user, I want to run the app locally (localhost by default), so that my financial data stays on my machine.
+2. As a user, I want password login with a secure session, so that my data isn’t accessible to anyone else who can reach my machine.
+3. As a user, I want to upload a CSV statement, so that my transactions can be ingested reliably.
+4. As a user, I want to upload a supported credit card PDF statement, so that I can ingest my primary card even when CSV export is inconvenient.
+5. As a user, I want uploads to complete in the background, so that the UI remains responsive.
+6. As a user, I want to see ingestion progress by step (extract → normalize → dedupe → categorize → persist), so that I can trust what’s happening.
+7. As a user, I want ingestion results to show counts (rows parsed/inserted/deduped), so that I can quickly spot problems.
+8. As a user, I want ingestion failures to show a clear error, so that I can fix the input or report a bug.
+9. As a user, I want raw statement files stored locally with metadata, so that I can re-run derived computations without re-uploading.
+10. As a user, I want the system to detect re-uploaded identical statements, so that I don’t create duplicates.
+11. As a user, I want transaction-level deduplication across overlapping statements, so that my ledger stays correct.
+12. As a user, I want each transaction to retain both transaction date and posted date when available, so that time-series views are accurate.
+13. As a user, I want a consistent signed-amount convention (income vs expense), so that analysis is predictable.
+14. As a user, I want my institutions and accounts represented explicitly, so that I can separate spending by account.
+15. As a user, I want account aliases, so that minor naming differences don’t split my ledger.
+16. As a user, I want a standard set of categories, so that I can start budgeting immediately.
+17. As a user, I want to customize categories (add/rename/merge) while keeping stable identifiers, so that budgets and history remain intact.
+18. As a user, I want my transactions categorized automatically using deterministic rules first, so that most items are categorized quickly and predictably.
+19. As a user, I want the system to use the LLM only for unknown/low-confidence categorization, so that I don’t waste tokens and reduce leakage of sensitive data.
+20. As a user, I want to manually correct a transaction’s category, so that I can fix mistakes.
+21. As a user, I want the system to propose a rule after I correct a category (apply to future, optionally retroactively), so that future imports improve.
+22. As a user, I want to create monthly envelope budgets per category, so that I can plan spending.
+23. As a user, I want a simple budget editor table, so that I can manage budgets quickly.
+24. As a user, I want a “suggest budgets from history” action, so that setup is faster.
+25. As a user, I want budget status to default to month-to-date with projections, so that I can see if I’m on track.
+26. As a user, I want to view cashflow (income vs expenses) over time, so that I understand my baseline.
+27. As a user, I want to view category spending over time, so that I can compare against budgets.
+28. As a user, I want to see recurring monthly charges (same merchant, similar amount, ≥3 occurrences), so that I can manage subscriptions.
+29. As a user, I want to see anomalies (spend spikes, new merchants, unusually large transactions) detected deterministically, so that I can trust the alerts.
+30. As a user, I want the agent to explain anomalies and suggest actions, so that I understand what changed.
+31. As a user, I want chat to stream responses, so that the experience feels responsive.
+32. As a user, I want to ask questions like “Why was March so expensive?” and get answers grounded in ledger data, so that insights are trustworthy.
+33. As a user, I want chat answers to use aggregates by default, so that I minimize sharing raw line-item details with the LLM provider.
+34. As a user, I want to drill down (“Explain this charge”) and explicitly allow minimal line-item context to be sent, so that I can resolve specific questions.
+35. As a user, I want the agent to be able to run read-only queries and use high-level tools, so that analysis is flexible but safe.
+36. As a user, I want the agent to ask for confirmation before any data-changing action, so that I stay in control.
+37. As a user, I want an ingestion review gate to trigger only when parser confidence is low, so that I don’t have to review every import.
+38. As a user, I want to soft-delete data by default, so that I can undo mistakes.
+39. As a user, I want a permanent purge option, so that I can fully delete sensitive data including raw files.
+40. As a user, I want to re-run derived computations (recategorize, re-score anomalies, re-normalize merchant names) without changing canonical transactions, so that improvements don’t rewrite history.
+41. As a user, I want the system to support multiple LLM providers behind a stable interface, so that I can switch providers later.
+42. As a user, I want tool calls and key agent steps traced in LangSmith, so that I can debug and audit agent behavior.
+43. As a user, I want the UI to have both a dedicated Upload page and chat-driven workflows, so that I can choose the most convenient interaction.
+44. As a user, I want charts to update after ingestion completes, so that I can immediately see results.
+45. As a user, I want ingestion to be idempotent across retries, so that transient failures don’t create duplicates.
+
+## Implementation Decisions
+
+- **Deployment model**
+  - Single-user self-hosted.
+  - Backend binds to localhost by default; future option to expose externally.
+
+- **Service topology**
+  - One backend service containing:
+    - An embedded MCP-shaped tool layer (tool schemas + deterministic implementations).
+    - The agent runtime (backend-run).
+  - Frontend is a separate web client that calls the backend.
+
+- **Auth and safety**
+  - Password login with secure session cookie.
+  - Confirm-before-write policy for agent: any tool that mutates state requires explicit user confirmation.
+
+- **Ingestion workflow**
+  - Asynchronous job model with a Postgres-backed durable queue.
+  - Step-level job status tracking with timestamps, counts, and surfaced errors.
+  - Raw uploaded files stored on disk with DB metadata and immutable content hash.
+  - Statement-level idempotency via file hash.
+  - Transaction-level dedupe via deterministic fingerprint and unique constraints.
+  - Import review gate only when parser confidence is low or validation signals trigger.
+
+- **Parsing scope and approach**
+  - MVP supports CSV ingestion and one targeted credit card PDF statement format.
+  - PDF extraction ladder: table extraction → text-line parsing → OCR fallback.
+
+- **Canonical data model (high level)**
+  - Entities: institution, account, account alias, statement, transaction, category, categorization rule, budget, recurring series, anomaly signal.
+  - Transactions include both transaction date and posted date (when present), signed amount convention, currency, raw and normalized description fields, source institution/account identifiers, and a `dedupe_fingerprint`.
+  - Categories are standard-by-default but user-customizable with stable internal identifiers.
+
+- **Derived computations and reprocessing**
+  - Support reprocessing derived fields (e.g., merchant normalization, categorization, anomaly scoring) without rewriting canonical transaction rows.
+
+- **Categorization strategy**
+  - Rules-first deterministic categorization.
+  - LLM used only for unknown/low-confidence cases; results cached.
+  - Manual corrections can apply to a single transaction and propose a general rule for future (and optional retroactive application).
+
+- **Analytics MVP scope**
+  - Envelope-style monthly budgets with MTD + projection.
+  - Recurring detection: monthly cadence, same merchant + similar amount, ≥3 occurrences.
+  - Anomaly detection: deterministic signals and simple robust stats; LLM produces explanations after detection.
+
+- **Agent tool surface**
+  - Provide high-level read tools (cashflow, budget status, recurring, anomalies, category breakdown).
+  - Provide a restricted read-only SQL query tool as an escape hatch for development and complex analysis.
+  - Privacy boundary: aggregates by default; drilldown sends minimal necessary raw data.
+
+- **Observability**
+  - Integrate LangSmith for agent/tool call traces.
+
+- **UI/UX**
+  - Dedicated Upload page plus chat commands.
+  - Streaming chat responses.
+  - Job progress via polling (streaming for jobs deferred).
+
+## Testing Decisions
+
+- **What makes a good test**
+  - Tests should validate external behavior and invariants (idempotency, dedupe correctness, parsing outcomes, tool contracts), not internal implementation details.
+
+- **Modules to test**
+  - Normalization + dedupe fingerprint generation (pure functions; deterministic outputs).
+  - CSV ingestion parser (mapping → canonical transaction records).
+  - Targeted PDF parser (given fixture PDFs, produces expected rows and confidence signals).
+  - Categorization engine (rules-first behavior; LLM fallback mocked).
+  - Recurring detection and anomaly detection (stable outputs on known datasets).
+  - Postgres-backed job queue semantics (enqueue, run, retry, status transitions).
+  - Agent tool contracts (input validation, output schemas, read-only enforcement).
+
+- **Prior art**
+  - Follow existing repository testing patterns (pytest-style) if present; otherwise establish a standard layout with deterministic fixtures and golden-file expectations for parsers.
+
+## Out of Scope
+
+- Multi-tenant SaaS, billing, and enterprise auth.
+- Full “generic PDF parsing for any institution” beyond the targeted first credit card format.
+- Real-time streaming of job step updates (SSE/WebSocket) in MVP.
+- Full observability stack beyond step-level statuses + LangSmith.
+- Automated bank connection (Plaid/open banking) in MVP.
+- Full “financial advice” or regulated recommendations; the agent provides analytics and summaries, not professional advice.
+
+## Further Notes
+
+- Privacy defaults are critical: most questions can be answered from aggregates; line-item sharing should require explicit user intent.
+- The readonly SQL tool is valuable for iteration but should be gated (auth + readonly enforcement) and potentially removed or locked down when exposing the service beyond localhost.
+- Parser confidence scoring is important to make the “review only when needed” gate trustworthy.

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Verifies issue #2 acceptance: compose config, Postgres readiness, connectivity,
+# and data persistence across container restart (named volume).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+ENV_EXAMPLE="${ROOT}/.env.example"
+COMPOSE_FILE="${ROOT}/compose.yaml"
+TEARDOWN_VOLUMES=false
+for arg in "$@"; do
+  case "$arg" in
+    --teardown-volumes) TEARDOWN_VOLUMES=true ;;
+    -h|--help)
+      echo "Usage: $0 [--teardown-volumes]"
+      echo "  --teardown-volumes  Run 'docker compose down -v' after checks (removes pg volume)."
+      exit 0
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found in PATH" >&2
+  exit 1
+fi
+
+if [[ ! -f "$ENV_EXAMPLE" ]]; then
+  echo "error: missing .env.example at $ENV_EXAMPLE" >&2
+  exit 1
+fi
+
+if [[ ! -f "$COMPOSE_FILE" ]]; then
+  echo "error: missing compose.yaml at $COMPOSE_FILE" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1090
+set -a && source "$ENV_EXAMPLE" && set +a
+
+export ENV_FILE="$ENV_EXAMPLE"
+DC=(docker compose --env-file "$ENV_EXAMPLE" -f "$COMPOSE_FILE")
+
+# Track whether this script started the db (so we never tear down a pre-existing stack).
+STACK_STARTED=0
+cleanup() {
+  local ec=$?
+  trap - EXIT
+  if [[ "$STACK_STARTED" -eq 1 ]]; then
+    if [[ "$TEARDOWN_VOLUMES" == true ]]; then
+      echo "==> docker compose down -v"
+      "${DC[@]}" down -v || true
+    else
+      echo "==> docker compose down (volumes retained)"
+      "${DC[@]}" down || true
+    fi
+  fi
+  exit "$ec"
+}
+trap cleanup EXIT
+
+mkdir -p "${RAW_STATEMENTS_HOST_PATH:-./data/raw-statements}"
+
+echo "==> compose config"
+"${DC[@]}" config -q
+
+wait_for_db() {
+  local attempts=60
+  local i
+  for ((i = 1; i <= attempts; i++)); do
+    if "${DC[@]}" exec -T db pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 1
+  done
+  echo "error: Postgres did not become ready within ${attempts}s" >&2
+  return 1
+}
+
+# Detect whether the db container was already running before this script touched it.
+# If it was, we leave it running on exit regardless of --teardown-volumes.
+DB_WAS_RUNNING=0
+if [[ -n "$("${DC[@]}" ps -q db 2>/dev/null)" ]]; then
+  DB_WAS_RUNNING=1
+fi
+
+echo "==> compose up"
+if "${DC[@]}" up -d --wait 2>/dev/null; then
+  :
+else
+  "${DC[@]}" up -d
+  wait_for_db
+fi
+# Only mark the stack for teardown if this script was the one that started it.
+if [[ "$DB_WAS_RUNNING" -eq 0 ]]; then
+  STACK_STARTED=1
+fi
+
+echo "==> connectivity (SELECT 1)"
+"${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null
+
+echo "==> persistence marker + container restart"
+"${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "
+CREATE TABLE IF NOT EXISTS _pfa_infra_issue2 (k text PRIMARY KEY, v text NOT NULL);
+INSERT INTO _pfa_infra_issue2 (k, v) VALUES ('marker', 'issue2-persist')
+  ON CONFLICT (k) DO UPDATE SET v = EXCLUDED.v;
+" >/dev/null
+
+"${DC[@]}" restart db >/dev/null
+
+if "${DC[@]}" up -d --wait 2>/dev/null; then
+  :
+else
+  wait_for_db
+fi
+
+marker="$("${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -At -c \
+  "SELECT v FROM _pfa_infra_issue2 WHERE k = 'marker';")"
+marker="$(echo "$marker" | tr -d '\r')"
+if [[ "$marker" != "issue2-persist" ]]; then
+  echo "error: expected persistence marker 'issue2-persist', got '${marker:-}'" >&2
+  exit 1
+fi
+
+echo "==> raw statements mount visible in container"
+"${DC[@]}" exec -T db sh -c "test -d '${RAW_STATEMENTS_CONTAINER_PATH:-/data/raw-statements}'"
+
+echo "All infra checks passed."

--- a/scripts/verify-infra.sh
+++ b/scripts/verify-infra.sh
@@ -25,6 +25,11 @@ if ! command -v docker >/dev/null 2>&1; then
   exit 1
 fi
 
+if ! docker compose version >/dev/null 2>&1; then
+  echo "error: 'docker compose' (Compose v2 plugin) not available; install Docker Compose v2" >&2
+  exit 1
+fi
+
 if [[ ! -f "$ENV_EXAMPLE" ]]; then
   echo "error: missing .env.example at $ENV_EXAMPLE" >&2
   exit 1
@@ -99,6 +104,18 @@ fi
 echo "==> connectivity (SELECT 1)"
 "${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "SELECT 1;" >/dev/null
 
+echo "==> host publish matches POSTGRES_PORT (backend wiring)"
+host_bind="$("${DC[@]}" port db 5432 2>/dev/null | tr -d '\r' || true)"
+if [[ -z "$host_bind" ]]; then
+  echo "error: could not read published port (docker compose port db 5432)" >&2
+  exit 1
+fi
+host_port="${host_bind##*:}"
+if [[ "$host_port" != "${POSTGRES_PORT}" ]]; then
+  echo "error: container publishes ${host_bind}; expected host port ${POSTGRES_PORT} (POSTGRES_PORT)" >&2
+  exit 1
+fi
+
 echo "==> persistence marker + container restart"
 "${DC[@]}" exec -T db psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 -c "
 CREATE TABLE IF NOT EXISTS _pfa_infra_issue2 (k text PRIMARY KEY, v text NOT NULL);
@@ -111,6 +128,7 @@ INSERT INTO _pfa_infra_issue2 (k, v) VALUES ('marker', 'issue2-persist')
 if "${DC[@]}" up -d --wait 2>/dev/null; then
   :
 else
+  "${DC[@]}" up -d
   wait_for_db
 fi
 


### PR DESCRIPTION
## Summary

Fast-forwards `master` from the pre-app baseline to include **slice 0**: Postgres via Docker Compose ([issue #2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2)), matching what landed on `main` via [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15).

## Contents

- `compose.yaml`, `.env.example`, `scripts/verify-infra.sh`, `Makefile`
- MVP README (getting started, slices table, teardown)
- `docs/PRD.md` + README link to canonical PRD ([issue #1](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/1))

## Verify

```bash
make verify-infra
```

Relates to #2

Made with [Cursor](https://cursor.com)