### PR TITLE
feat(backend): slice 7 — rules-first categorization + corrections + rule proposals

### DIFF
--- a/backend/pfa/categorization.py
+++ b/backend/pfa/categorization.py
@@ -2,59 +2,52 @@
 
 from __future__ import annotations
 
-import re
-
 import psycopg
 
 
 def apply_rules(conn: psycopg.Connection, transaction_id: str) -> str | None:
-    tx = conn.execute(
-        "SELECT description_normalized FROM transactions WHERE id = %s AND category_id IS NULL",
+    row = conn.execute(
+        """
+        UPDATE transactions
+        SET category_id = (
+            SELECT r.category_id
+            FROM categorization_rules r
+            WHERE transactions.description_normalized ~* r.pattern
+            ORDER BY r.priority ASC, r.created_at ASC
+            LIMIT 1
+        )
+        WHERE id = %s
+          AND category_id IS NULL
+          AND EXISTS (
+              SELECT 1 FROM categorization_rules r
+              WHERE transactions.description_normalized ~* r.pattern
+          )
+        RETURNING category_id
+        """,
         (transaction_id,),
     ).fetchone()
-    if tx is None:
-        return None
-    desc = tx[0]
-    rules = conn.execute(
-        "SELECT category_id, pattern FROM categorization_rules ORDER BY priority ASC, created_at ASC"
-    ).fetchall()
-    for category_id, pattern in rules:
-        try:
-            if re.search(pattern, desc, re.IGNORECASE):
-                conn.execute(
-                    "UPDATE transactions SET category_id = %s WHERE id = %s",
-                    (str(category_id), transaction_id),
-                )
-                return str(category_id)
-        except re.error:
-            continue
-    return None
+    return str(row[0]) if row else None
 
 
 def apply_rules_to_all_uncategorized(conn: psycopg.Connection) -> int:
-    rules = conn.execute(
-        "SELECT category_id, pattern FROM categorization_rules ORDER BY priority ASC, created_at ASC"
-    ).fetchall()
-    if not rules:
-        return 0
-    txs = conn.execute(
-        "SELECT id, description_normalized FROM transactions WHERE category_id IS NULL"
-    ).fetchall()
-    updated = 0
-    with conn.cursor() as cur:
-        for tx_id, desc in txs:
-            for category_id, pattern in rules:
-                try:
-                    if re.search(pattern, desc, re.IGNORECASE):
-                        cur.execute(
-                            "UPDATE transactions SET category_id = %s WHERE id = %s",
-                            (str(category_id), str(tx_id)),
-                        )
-                        updated += 1
-                        break
-                except re.error:
-                    continue
-    return updated
+    result = conn.execute(
+        """
+        UPDATE transactions
+        SET category_id = (
+            SELECT r.category_id
+            FROM categorization_rules r
+            WHERE transactions.description_normalized ~* r.pattern
+            ORDER BY r.priority ASC, r.created_at ASC
+            LIMIT 1
+        )
+        WHERE category_id IS NULL
+          AND EXISTS (
+              SELECT 1 FROM categorization_rules r
+              WHERE transactions.description_normalized ~* r.pattern
+          )
+        """
+    )
+    return result.rowcount
 
 
 def apply_rules_retroactively(conn: psycopg.Connection, rule_id: str) -> int:
@@ -65,19 +58,13 @@ def apply_rules_retroactively(conn: psycopg.Connection, rule_id: str) -> int:
     if rule is None:
         return 0
     pattern, category_id = rule
-    txs = conn.execute(
-        "SELECT id, description_normalized FROM transactions WHERE category_id IS NULL"
-    ).fetchall()
-    updated = 0
-    with conn.cursor() as cur:
-        for tx_id, desc in txs:
-            try:
-                if re.search(pattern, desc, re.IGNORECASE):
-                    cur.execute(
-                        "UPDATE transactions SET category_id = %s WHERE id = %s",
-                        (str(category_id), str(tx_id)),
-                    )
-                    updated += 1
-            except re.error:
-                break
-    return updated
+    result = conn.execute(
+        """
+        UPDATE transactions
+        SET category_id = %s
+        WHERE category_id IS NULL
+          AND description_normalized ~* %s
+        """,
+        (str(category_id), pattern),
+    )
+    return result.rowcount

--- a/backend/pfa/categorization.py
+++ b/backend/pfa/categorization.py
@@ -1,0 +1,83 @@
+"""Rules-first deterministic categorization engine (slice 7)."""
+
+from __future__ import annotations
+
+import re
+
+import psycopg
+
+
+def apply_rules(conn: psycopg.Connection, transaction_id: str) -> str | None:
+    tx = conn.execute(
+        "SELECT description_normalized FROM transactions WHERE id = %s AND category_id IS NULL",
+        (transaction_id,),
+    ).fetchone()
+    if tx is None:
+        return None
+    desc = tx[0]
+    rules = conn.execute(
+        "SELECT category_id, pattern FROM categorization_rules ORDER BY priority ASC, created_at ASC"
+    ).fetchall()
+    for category_id, pattern in rules:
+        try:
+            if re.search(pattern, desc, re.IGNORECASE):
+                conn.execute(
+                    "UPDATE transactions SET category_id = %s WHERE id = %s",
+                    (str(category_id), transaction_id),
+                )
+                return str(category_id)
+        except re.error:
+            continue
+    return None
+
+
+def apply_rules_to_all_uncategorized(conn: psycopg.Connection) -> int:
+    rules = conn.execute(
+        "SELECT category_id, pattern FROM categorization_rules ORDER BY priority ASC, created_at ASC"
+    ).fetchall()
+    if not rules:
+        return 0
+    txs = conn.execute(
+        "SELECT id, description_normalized FROM transactions WHERE category_id IS NULL"
+    ).fetchall()
+    updated = 0
+    with conn.cursor() as cur:
+        for tx_id, desc in txs:
+            for category_id, pattern in rules:
+                try:
+                    if re.search(pattern, desc, re.IGNORECASE):
+                        cur.execute(
+                            "UPDATE transactions SET category_id = %s WHERE id = %s",
+                            (str(category_id), str(tx_id)),
+                        )
+                        updated += 1
+                        break
+                except re.error:
+                    continue
+    return updated
+
+
+def apply_rules_retroactively(conn: psycopg.Connection, rule_id: str) -> int:
+    rule = conn.execute(
+        "SELECT pattern, category_id FROM categorization_rules WHERE id = %s",
+        (rule_id,),
+    ).fetchone()
+    if rule is None:
+        return 0
+    pattern, category_id = rule
+    txs = conn.execute(
+        "SELECT id, description_normalized FROM transactions WHERE category_id IS NULL"
+    ).fetchall()
+    updated = 0
+    with conn.cursor() as cur:
+        for tx_id, desc in txs:
+            try:
+                if re.search(pattern, desc, re.IGNORECASE):
+                    cur.execute(
+                        "UPDATE transactions SET category_id = %s WHERE id = %s",
+                        (str(category_id), str(tx_id)),
+                    )
+                    updated += 1
+            except re.error:
+                break
+    return updated

--- a/backend/pfa/categorization_api.py
+++ b/backend/pfa/categorization_api.py
@@ -1,0 +1,162 @@
+"""HTTP routes for categorization rules, manual corrections, and rule proposals (slice 7)."""
+
+from __future__ import annotations
+
+import re
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from pfa.categorization import apply_rules_retroactively
+from pfa.db import connect
+
+router = APIRouter(tags=["categorization"])
+
+
+class RuleCreate(BaseModel):
+    category_id: UUID
+    pattern: str = Field(min_length=1)
+    priority: int = Field(default=100)
+    apply_retroactively: bool = False
+
+
+class RuleOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    category_id: UUID
+    category_name: str
+    pattern: str
+    priority: int
+
+
+class CategoryPatch(BaseModel):
+    category_id: UUID
+
+
+class TransactionOut(BaseModel):
+    id: UUID
+    category_id: UUID | None
+
+
+class RuleProposalIn(BaseModel):
+    pattern: str = Field(min_length=1)
+    apply_retroactively: bool = False
+
+
+class RuleProposalOut(BaseModel):
+    proposed_rule: dict
+    would_affect_count: int
+
+
+@router.get("/categorization/rules", response_model=list[RuleOut])
+def list_rules():
+    with connect() as conn:
+        rows = conn.execute(
+            """
+            SELECT r.id, r.category_id, c.name, r.pattern, r.priority
+            FROM categorization_rules r
+            JOIN categories c ON c.id = r.category_id
+            ORDER BY r.priority ASC, r.created_at ASC
+            """
+        ).fetchall()
+    return [
+        RuleOut(id=r[0], category_id=r[1], category_name=r[2], pattern=r[3], priority=r[4])
+        for r in rows
+    ]
+
+
+@router.post("/categorization/rules", response_model=RuleOut, status_code=201)
+def create_rule(body: RuleCreate):
+    try:
+        re.compile(body.pattern)
+    except re.error as exc:
+        raise HTTPException(status_code=422, detail=f"invalid regex: {exc}") from exc
+
+    with connect() as conn:
+        cat = conn.execute(
+            "SELECT id, name FROM categories WHERE id = %s", (str(body.category_id),)
+        ).fetchone()
+        if cat is None:
+            raise HTTPException(status_code=404, detail="category not found")
+
+        row = conn.execute(
+            """
+            INSERT INTO categorization_rules (category_id, pattern, priority)
+            VALUES (%s, %s, %s) RETURNING id
+            """,
+            (str(body.category_id), body.pattern, body.priority),
+        ).fetchone()
+        rule_id = row[0]
+
+        if body.apply_retroactively:
+            apply_rules_retroactively(conn, str(rule_id))
+
+        conn.commit()
+
+    return RuleOut(
+        id=rule_id,
+        category_id=body.category_id,
+        category_name=cat[1],
+        pattern=body.pattern,
+        priority=body.priority,
+    )
+
+
+@router.delete("/categorization/rules/{rule_id}", status_code=204)
+def delete_rule(rule_id: UUID):
+    with connect() as conn:
+        result = conn.execute(
+            "DELETE FROM categorization_rules WHERE id = %s RETURNING id",
+            (str(rule_id),),
+        ).fetchone()
+        if result is None:
+            raise HTTPException(status_code=404, detail="rule not found")
+        conn.commit()
+
+
+@router.put("/transactions/{transaction_id}/category", response_model=TransactionOut)
+def update_transaction_category(transaction_id: UUID, body: CategoryPatch):
+    with connect() as conn:
+        cat = conn.execute(
+            "SELECT id FROM categories WHERE id = %s", (str(body.category_id),)
+        ).fetchone()
+        if cat is None:
+            raise HTTPException(status_code=404, detail="category not found")
+
+        result = conn.execute(
+            "UPDATE transactions SET category_id = %s WHERE id = %s RETURNING id, category_id",
+            (str(body.category_id), str(transaction_id)),
+        ).fetchone()
+        if result is None:
+            raise HTTPException(status_code=404, detail="transaction not found")
+        conn.commit()
+
+    return TransactionOut(id=result[0], category_id=result[1])
+
+
+@router.post("/transactions/{transaction_id}/rule-proposal", response_model=RuleProposalOut)
+def propose_rule(transaction_id: UUID, body: RuleProposalIn):
+    try:
+        re.compile(body.pattern)
+    except re.error as exc:
+        raise HTTPException(status_code=422, detail=f"invalid regex: {exc}") from exc
+
+    with connect() as conn:
+        tx = conn.execute(
+            "SELECT id FROM transactions WHERE id = %s", (str(transaction_id),)
+        ).fetchone()
+        if tx is None:
+            raise HTTPException(status_code=404, detail="transaction not found")
+
+        count_row = conn.execute(
+            "SELECT COUNT(*) FROM transactions WHERE category_id IS NULL AND description_normalized ~* %s",
+            (body.pattern,),
+        ).fetchone()
+        would_affect = count_row[0] if count_row else 0
+
+    return RuleProposalOut(
+        proposed_rule={"pattern": body.pattern, "apply_retroactively": body.apply_retroactively},
+        would_affect_count=would_affect,
+    )

--- a/backend/pfa/categorization_api.py
+++ b/backend/pfa/categorization_api.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-import re
 from uuid import UUID
 
+import psycopg
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -16,7 +16,7 @@ router = APIRouter(tags=["categorization"])
 
 class RuleCreate(BaseModel):
     category_id: UUID
-    pattern: str = Field(min_length=1)
+    pattern: str = Field(min_length=1, max_length=500)
     priority: int = Field(default=100)
     apply_retroactively: bool = False
 
@@ -41,13 +41,21 @@ class TransactionOut(BaseModel):
 
 
 class RuleProposalIn(BaseModel):
-    pattern: str = Field(min_length=1)
+    pattern: str = Field(min_length=1, max_length=500)
     apply_retroactively: bool = False
 
 
 class RuleProposalOut(BaseModel):
     proposed_rule: dict
     would_affect_count: int
+
+
+def _validate_postgres_regex(conn: psycopg.Connection, pattern: str) -> None:
+    """Raise 422 if Postgres rejects the pattern (avoids Python/Postgres engine mismatch)."""
+    try:
+        conn.execute("SELECT '' ~* %s", (pattern,))
+    except psycopg.errors.InvalidRegularExpression as exc:
+        raise HTTPException(status_code=422, detail=f"invalid regex: {exc}") from exc
 
 
 @router.get("/categorization/rules", response_model=list[RuleOut])
@@ -69,12 +77,9 @@ def list_rules():
 
 @router.post("/categorization/rules", response_model=RuleOut, status_code=201)
 def create_rule(body: RuleCreate):
-    try:
-        re.compile(body.pattern)
-    except re.error as exc:
-        raise HTTPException(status_code=422, detail=f"invalid regex: {exc}") from exc
-
     with connect() as conn:
+        _validate_postgres_regex(conn, body.pattern)
+
         cat = conn.execute(
             "SELECT id, name FROM categories WHERE id = %s", (str(body.category_id),)
         ).fetchone()
@@ -138,17 +143,14 @@ def update_transaction_category(transaction_id: UUID, body: CategoryPatch):
 
 @router.post("/transactions/{transaction_id}/rule-proposal", response_model=RuleProposalOut)
 def propose_rule(transaction_id: UUID, body: RuleProposalIn):
-    try:
-        re.compile(body.pattern)
-    except re.error as exc:
-        raise HTTPException(status_code=422, detail=f"invalid regex: {exc}") from exc
-
     with connect() as conn:
         tx = conn.execute(
             "SELECT id FROM transactions WHERE id = %s", (str(transaction_id),)
         ).fetchone()
         if tx is None:
             raise HTTPException(status_code=404, detail="transaction not found")
+
+        _validate_postgres_regex(conn, body.pattern)
 
         count_row = conn.execute(
             "SELECT COUNT(*) FROM transactions WHERE category_id IS NULL AND description_normalized ~* %s",

--- a/backend/pfa/ingest.py
+++ b/backend/pfa/ingest.py
@@ -8,6 +8,7 @@ from uuid import UUID
 
 import psycopg
 
+from pfa.categorization import apply_rules
 from pfa.csv_parse import ParsedCsvRow
 from pfa.dedupe import normalize_description, transaction_fingerprint
 
@@ -37,7 +38,7 @@ def ingest_rows(
                 row.amount,
                 desc_norm,
             )
-            cur.execute(
+            result = cur.execute(
                 """
                 INSERT INTO transactions (
                   account_id, transaction_date, posted_date, amount, currency,
@@ -45,6 +46,7 @@ def ingest_rows(
                   source_statement_id
                 ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
                 ON CONFLICT (dedupe_fingerprint) DO NOTHING
+                RETURNING id
                 """,
                 (
                     str(account_id),
@@ -57,9 +59,10 @@ def ingest_rows(
                     fp,
                     str(source_statement_id) if source_statement_id else None,
                 ),
-            )
-            if cur.rowcount == 1:
+            ).fetchone()
+            if result is not None:
                 inserted += 1
+                apply_rules(conn, str(result[0]))
             else:
                 skipped += 1
     return inserted, skipped

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 
 from pfa.budget_api import router as budget_router
+from pfa.categorization_api import router as categorization_router
 from pfa.recurring_api import router as recurring_router
 from pfa.csv_parse import CsvParseError, parse_csv_bytes
 from pfa.db import connect, ensure_schema
@@ -47,6 +48,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Personal Financial Analyst", lifespan=lifespan)
 
 app.include_router(budget_router)
+app.include_router(categorization_router)
 app.include_router(recurring_router)
 
 

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -11,6 +11,7 @@ from fastapi import FastAPI, File, Form, HTTPException, UploadFile
 from pydantic import BaseModel
 
 from pfa.budget_api import router as budget_router
+from pfa.categorization_api import router as categorization_router
 from pfa.csv_parse import CsvParseError, parse_csv_bytes
 from pfa.db import connect, ensure_schema
 from pfa.ingest import (
@@ -46,6 +47,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Personal Financial Analyst", lifespan=lifespan)
 
 app.include_router(budget_router)
+app.include_router(categorization_router)
 
 
 @app.get("/health")

--- a/backend/pfa/schema.sql
+++ b/backend/pfa/schema.sql
@@ -86,3 +86,14 @@ CREATE INDEX IF NOT EXISTS idx_budgets_month ON budgets(month);
 ALTER TABLE transactions ADD COLUMN IF NOT EXISTS category_id UUID REFERENCES categories(id) ON DELETE SET NULL;
 
 CREATE INDEX IF NOT EXISTS idx_transactions_category_date ON transactions(category_id, transaction_date);
+
+-- Slice 7: deterministic categorization rules.
+CREATE TABLE IF NOT EXISTS categorization_rules (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  category_id UUID NOT NULL REFERENCES categories(id) ON DELETE CASCADE,
+  pattern TEXT NOT NULL,
+  priority INTEGER NOT NULL DEFAULT 100,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cat_rules_priority ON categorization_rules(priority);

--- a/backend/tests/test_categorization.py
+++ b/backend/tests/test_categorization.py
@@ -1,0 +1,130 @@
+"""Rules-first categorization + manual correction + rule proposal (integration)."""
+
+from __future__ import annotations
+
+import datetime
+import uuid
+
+import pytest
+
+from pfa.categorization import apply_rules
+from pfa.db import connect
+
+pytestmark = pytest.mark.integration
+
+
+def _insert_transaction(clean_db, account_id: uuid.UUID, description: str, amount: str = "-50.00") -> uuid.UUID:
+    tx_id = uuid.uuid4()
+    with clean_db.cursor() as cur:
+        cur.execute(
+            """
+            INSERT INTO transactions (
+              id, account_id, transaction_date, amount, currency,
+              description_raw, description_normalized, dedupe_fingerprint
+            ) VALUES (%s, %s, %s, %s, 'USD', %s, %s, %s)
+            """,
+            (str(tx_id), str(account_id), datetime.date(2025, 1, 15),
+             amount, description, description, f"fp-{uuid.uuid4()}"),
+        )
+    clean_db.commit()
+    return tx_id
+
+
+def _create_category(client, slug: str, name: str) -> str:
+    r = client.post("/categories", json={"slug": slug, "name": name})
+    assert r.status_code == 200
+    return r.json()["id"]
+
+
+def test_rule_matches_and_categorizes(client, sample_account_id, clean_db):
+    cid = _create_category(client, "streaming", "Streaming")
+    tx_id = _insert_transaction(clean_db, sample_account_id, "netflix subscription")
+
+    r = client.post(
+        "/categorization/rules",
+        json={"category_id": cid, "pattern": "netflix", "priority": 100, "apply_retroactively": True},
+    )
+    assert r.status_code == 201
+
+    with clean_db.cursor() as cur:
+        cur.execute("SELECT category_id FROM transactions WHERE id = %s", (str(tx_id),))
+        row = cur.fetchone()
+    assert str(row[0]) == cid
+
+
+def test_priority_lower_number_wins(client, sample_account_id, clean_db):
+    cid_a = _create_category(client, "cat-a", "Cat A")
+    cid_b = _create_category(client, "cat-b", "Cat B")
+    tx_id = _insert_transaction(clean_db, sample_account_id, "amazon prime membership")
+
+    client.post("/categorization/rules", json={"category_id": cid_a, "pattern": "amazon", "priority": 50})
+    client.post("/categorization/rules", json={"category_id": cid_b, "pattern": "amazon", "priority": 200})
+
+    with connect() as conn:
+        matched = apply_rules(conn, str(tx_id))
+        conn.commit()
+
+    assert matched == cid_a
+
+
+def test_no_matching_rule_leaves_uncategorized(client, sample_account_id, clean_db):
+    cid = _create_category(client, "streaming2", "Streaming 2")
+    tx_id = _insert_transaction(clean_db, sample_account_id, "random merchant xyz")
+    client.post("/categorization/rules", json={"category_id": cid, "pattern": "netflix"})
+
+    with connect() as conn:
+        matched = apply_rules(conn, str(tx_id))
+        conn.commit()
+
+    assert matched is None
+
+    with clean_db.cursor() as cur:
+        cur.execute("SELECT category_id FROM transactions WHERE id = %s", (str(tx_id),))
+        row = cur.fetchone()
+    assert row[0] is None
+
+
+def test_invalid_regex_returns_422(client):
+    cid = _create_category(client, "misc", "Misc")
+    r = client.post("/categorization/rules", json={"category_id": cid, "pattern": "[invalid("})
+    assert r.status_code == 422
+
+
+def test_manual_category_correction(client, sample_account_id, clean_db):
+    cid = _create_category(client, "groceries", "Groceries")
+    tx_id = _insert_transaction(clean_db, sample_account_id, "whole foods market")
+
+    r = client.put(f"/transactions/{tx_id}/category", json={"category_id": cid})
+    assert r.status_code == 200
+    assert r.json()["category_id"] == cid
+
+
+def test_manual_correction_unknown_transaction_404(client):
+    cid = _create_category(client, "transport", "Transport")
+    r = client.put(f"/transactions/{uuid.uuid4()}/category", json={"category_id": cid})
+    assert r.status_code == 404
+
+
+def test_rule_proposal_dry_run_does_not_persist(client, sample_account_id, clean_db):
+    cid = _create_category(client, "rides", "Rides")
+    tx_id1 = _insert_transaction(clean_db, sample_account_id, "uber trip")
+    tx_id2 = _insert_transaction(clean_db, sample_account_id, "uber eats order")
+
+    r = client.post(
+        f"/transactions/{tx_id1}/rule-proposal",
+        json={"pattern": "uber", "apply_retroactively": True},
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["proposed_rule"]["pattern"] == "uber"
+    assert body["would_affect_count"] == 2
+
+    # Dry-run must not create a rule
+    rules = client.get("/categorization/rules").json()
+    assert rules == []
+
+    # Transactions must remain uncategorized
+    with clean_db.cursor() as cur:
+        cur.execute("SELECT category_id FROM transactions WHERE id = ANY(%s)", ([str(tx_id1), str(tx_id2)],))
+        rows = cur.fetchall()
+    assert all(r[0] is None for r in rows)


### PR DESCRIPTION
## Summary

- Adds `categorization_rules` table with regex pattern matching and priority ordering (lower number = higher priority)
- `apply_rules()` called per-transaction during CSV ingest via `RETURNING id` (replaces `rowcount` check)
- `apply_rules_retroactively()` bulk-applies a new rule to all currently uncategorized transactions
- `PUT /transactions/{id}/category` for manual one-off correction (never clobbered by auto-rules)
- `POST /transactions/{id}/rule-proposal` is a dry-run: returns `would_affect_count` without persisting anything — satisfies the confirm-before-write requirement from PRD
- Closes #9

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `GET` | `/categorization/rules` | List all rules ordered by priority |
| `POST` | `/categorization/rules` | Create rule (validates regex, optional retroactive apply) |
| `DELETE` | `/categorization/rules/{rule_id}` | Delete rule |
| `PUT` | `/transactions/{id}/category` | Manual category correction |
| `POST` | `/transactions/{id}/rule-proposal` | Dry-run: preview would_affect_count |

## Test plan

- [x] Rule matches transaction by regex → `category_id` set
- [x] Lower priority number wins over higher number (tie-break by `created_at`)
- [x] No matching rule → `category_id` remains `NULL`
- [x] Invalid regex pattern → 422
- [x] Manual correction updates `category_id`
- [x] Unknown transaction correction → 404
- [x] Rule proposal dry-run returns count without persisting rule or updating transactions
- [x] All 43 tests pass (36 pre-existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)