### PR TITLE
feat(backend): slice 12 — PDF ingest stub + HITL gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Self-hosted personal finance stack: ingest bank and credit card statements (CSV 
 | 9 | Anomaly detection + UI | [#11](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/11) | Planned |
 | 10 | Agent + tools + streaming chat | [#12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12) | **Implemented** |
 | 11 | LangSmith tracing | [#13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13) | **Implemented** |
-| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) | Planned |
+| 12 | Targeted credit card PDF (HITL) | [#14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14) | **Implemented** |
 
 **Slice 0** in this repo: [`compose.yaml`](compose.yaml), [`.env.example`](.env.example), [`scripts/verify-infra.sh`](scripts/verify-infra.sh), [`Makefile`](Makefile) (`verify-infra`). Tracked in [issue #2](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/2); shipped on **`main`** via [#15](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/15) with follow-ups in [#17](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/17). Canonical PRD file added in [#16](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/pull/16).
 
@@ -31,6 +31,8 @@ Self-hosted personal finance stack: ingest bank and credit card statements (CSV 
 **Slice 10** ([issue #12](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/12)): Embedded **MCP-shaped** read tools plus **SSE streaming chat**. **`GET /chat/tools`** returns JSON-schema manifests (`ledger_summary`: aggregate counts and expense/income totals, optional `account_id`). **`POST /chat/stream`** accepts `{ "message": "..." }` and emits **`text/event-stream`** frames (`tool_call`, `tool_result`, `delta`, `done`). The MVP planner is **deterministic** (keyword routing); swap-in LLM planner later without changing tool contracts.
 
 **Slice 11** ([issue #13](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/13)): **Optional LangSmith** wrapping on **`invoke_tool`** via **`LANGCHAIN_TRACING_V2=true`** (+ **`LANGCHAIN_API_KEY`**, **`LANGCHAIN_PROJECT`**). When tracing is off or **`langsmith`** is missing, behavior matches the slice 10 path. See [`.env.example`](.env.example).
+
+**Slice 12** ([issue #14](https://github.com/chandra-jagarlamudi/PersonalFinancialAnalyst/issues/14)): **`POST /ingest/pdf`** (multipart **`account_id`** + **`file`**, same size cap as CSV) validates a **`%PDF`** header, runs the targeted credit-card parser ladder (**stub v0**: no rows, confidence **0.35**), and returns **`requires_hitl`** plus **`parser_notes`** without persisting transactions until confidence and row extraction justify auto-ingest (501 placeholder if that path triggers).
 
 ---
 

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 from contextlib import asynccontextmanager
+from decimal import Decimal
 from typing import Annotated
 from uuid import UUID
 
@@ -42,7 +43,7 @@ class IngestResponse(BaseModel):
 class PdfIngestResponse(BaseModel):
     inserted: int
     skipped_duplicates: int = 0
-    confidence: str
+    confidence: Decimal
     requires_hitl: bool
     parser_notes: str
     duplicate_statement: bool = False
@@ -164,7 +165,7 @@ def ingest_pdf(
     return PdfIngestResponse(
         inserted=0,
         skipped_duplicates=0,
-        confidence=str(outcome.confidence),
+        confidence=outcome.confidence,
         requires_hitl=hitl,
         parser_notes=outcome.notes,
         statement_id=None,

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -25,9 +25,11 @@ from pfa.ingest import (
     statement_exists_by_hash,
     update_statement_counts,
 )
+from pfa.pdf_cc import parse_targeted_credit_card_pdf_stub, outcome_requires_hitl
 from pfa.storage import delete_file, sha256_hex, store
 
 MAX_CSV_UPLOAD_BYTES = 10 * 1024 * 1024
+MAX_PDF_UPLOAD_BYTES = MAX_CSV_UPLOAD_BYTES
 
 
 class IngestResponse(BaseModel):
@@ -35,6 +37,16 @@ class IngestResponse(BaseModel):
     skipped_duplicates: int
     statement_id: str
     duplicate_statement: bool = False
+
+
+class PdfIngestResponse(BaseModel):
+    inserted: int
+    skipped_duplicates: int = 0
+    confidence: str
+    requires_hitl: bool
+    parser_notes: str
+    duplicate_statement: bool = False
+    statement_id: str | None = None
 
 
 @asynccontextmanager
@@ -111,6 +123,51 @@ def ingest_csv(
         inserted=inserted,
         skipped_duplicates=skipped,
         statement_id=str(stmt_id),
+    )
+
+
+def _ensure_pdf_magic(raw: bytes) -> None:
+    if len(raw) < 5 or not raw.startswith(b"%PDF"):
+        raise HTTPException(
+            status_code=422,
+            detail="PDF uploads must begin with a %PDF header",
+        )
+
+
+@app.post("/ingest/pdf", response_model=PdfIngestResponse)
+def ingest_pdf(
+    account_id: Annotated[UUID, Form()],
+    file: Annotated[UploadFile, File()],
+):
+    raw = file.file.read(MAX_PDF_UPLOAD_BYTES + 1)
+    if len(raw) > MAX_PDF_UPLOAD_BYTES:
+        raise HTTPException(
+            status_code=413,
+            detail=f"PDF exceeds maximum size of {MAX_PDF_UPLOAD_BYTES} bytes",
+        )
+
+    _ensure_pdf_magic(raw)
+
+    with connect() as conn:
+        if not account_exists(conn, account_id):
+            raise HTTPException(status_code=404, detail="account not found")
+
+    outcome = parse_targeted_credit_card_pdf_stub(raw)
+    hitl = outcome_requires_hitl(outcome)
+
+    if not hitl:
+        raise HTTPException(
+            status_code=501,
+            detail="PDF auto-ingest path not implemented yet (parser produced rows with sufficient confidence)",
+        )
+
+    return PdfIngestResponse(
+        inserted=0,
+        skipped_duplicates=0,
+        confidence=str(outcome.confidence),
+        requires_hitl=hitl,
+        parser_notes=outcome.notes,
+        statement_id=None,
     )
 
 

--- a/backend/pfa/pdf_cc.py
+++ b/backend/pfa/pdf_cc.py
@@ -1,0 +1,38 @@
+"""Targeted credit-card PDF parse ladder (slice 12) — stub + confidence for HITL gate."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+
+from pfa.csv_parse import ParsedCsvRow
+
+HITL_CONFIDENCE_THRESHOLD = Decimal("0.85")
+
+
+@dataclass(frozen=True, slots=True)
+class TargetedPdfParseOutcome:
+    rows: tuple[ParsedCsvRow, ...]
+    confidence: Decimal
+    notes: str
+
+
+def parse_targeted_credit_card_pdf_stub(raw: bytes) -> TargetedPdfParseOutcome:
+    """Placeholder until the institution-specific parser ships (table → text → OCR ladder)."""
+    _ = raw
+    return TargetedPdfParseOutcome(
+        (),
+        Decimal("0.35"),
+        "stub_parser_v0:no_rows",
+    )
+
+
+def requires_hitl(confidence: Decimal, *, threshold: Decimal = HITL_CONFIDENCE_THRESHOLD) -> bool:
+    return confidence < threshold
+
+
+def outcome_requires_hitl(outcome: TargetedPdfParseOutcome) -> bool:
+    """Human review when confidence is low or the parser produced no rows to persist."""
+    if outcome.confidence < HITL_CONFIDENCE_THRESHOLD:
+        return True
+    return len(outcome.rows) == 0

--- a/backend/pfa/pdf_cc.py
+++ b/backend/pfa/pdf_cc.py
@@ -31,8 +31,12 @@ def requires_hitl(confidence: Decimal, *, threshold: Decimal = HITL_CONFIDENCE_T
     return confidence < threshold
 
 
-def outcome_requires_hitl(outcome: TargetedPdfParseOutcome) -> bool:
+def outcome_requires_hitl(
+    outcome: TargetedPdfParseOutcome,
+    *,
+    threshold: Decimal = HITL_CONFIDENCE_THRESHOLD,
+) -> bool:
     """Human review when confidence is low or the parser produced no rows to persist."""
-    if outcome.confidence < HITL_CONFIDENCE_THRESHOLD:
+    if requires_hitl(outcome.confidence, threshold=threshold):
         return True
     return len(outcome.rows) == 0

--- a/backend/tests/test_pdf_cc.py
+++ b/backend/tests/test_pdf_cc.py
@@ -1,0 +1,44 @@
+"""Targeted PDF parse outcomes (slice 12) — pure tests."""
+
+from __future__ import annotations
+
+import datetime
+from decimal import Decimal
+
+from pfa.csv_parse import ParsedCsvRow
+from pfa.pdf_cc import (
+    HITL_CONFIDENCE_THRESHOLD,
+    outcome_requires_hitl,
+    parse_targeted_credit_card_pdf_stub,
+    requires_hitl,
+    TargetedPdfParseOutcome,
+)
+
+
+def test_stub_parser_low_confidence_empty_rows():
+    out = parse_targeted_credit_card_pdf_stub(b"%PDF-1.4\n")
+    assert out.rows == ()
+    assert out.confidence == Decimal("0.35")
+    assert outcome_requires_hitl(out) is True
+
+
+def test_outcome_requires_hitl_when_high_confidence_but_no_rows():
+    o = TargetedPdfParseOutcome((), Decimal("0.95"), "test")
+    assert outcome_requires_hitl(o) is True
+
+
+def test_outcome_allows_auto_when_confident_and_rows():
+    row = ParsedCsvRow(
+        transaction_date=datetime.date(2025, 1, 1),
+        posted_date=None,
+        amount=Decimal("-1"),
+        currency="USD",
+        description_raw="x",
+    )
+    o = TargetedPdfParseOutcome((row,), Decimal("0.95"), "test")
+    assert outcome_requires_hitl(o) is False
+
+
+def test_requires_hitl_threshold_boundary():
+    assert requires_hitl(HITL_CONFIDENCE_THRESHOLD - Decimal("0.01")) is True
+    assert requires_hitl(HITL_CONFIDENCE_THRESHOLD) is False

--- a/backend/tests/test_pdf_cc.py
+++ b/backend/tests/test_pdf_cc.py
@@ -42,3 +42,20 @@ def test_outcome_allows_auto_when_confident_and_rows():
 def test_requires_hitl_threshold_boundary():
     assert requires_hitl(HITL_CONFIDENCE_THRESHOLD - Decimal("0.01")) is True
     assert requires_hitl(HITL_CONFIDENCE_THRESHOLD) is False
+
+
+def test_outcome_requires_hitl_honors_threshold_override():
+    o = TargetedPdfParseOutcome(
+        (
+            ParsedCsvRow(
+                transaction_date=datetime.date(2025, 1, 1),
+                posted_date=None,
+                amount=Decimal("-1"),
+                currency="USD",
+                description_raw="x",
+            ),
+        ),
+        Decimal("0.80"),
+        "test",
+    )
+    assert outcome_requires_hitl(o, threshold=Decimal("0.75")) is False

--- a/backend/tests/test_pdf_ingest_http.py
+++ b/backend/tests/test_pdf_ingest_http.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+import datetime
+from decimal import Decimal
 import uuid
 
 import pytest
+
+from pfa.csv_parse import ParsedCsvRow
+from pfa.pdf_cc import TargetedPdfParseOutcome
 
 pytestmark = pytest.mark.integration
 
@@ -35,3 +40,38 @@ def test_ingest_pdf_unknown_account(client):
     data = {"account_id": str(uuid.uuid4())}
     r = client.post("/ingest/pdf", files=files, data=data)
     assert r.status_code == 404
+
+
+def test_ingest_pdf_over_max_size_returns_413(client, sample_account_id, monkeypatch):
+    from pfa import main
+
+    monkeypatch.setattr(main, "MAX_PDF_UPLOAD_BYTES", 32)
+    files = {"file": ("stmt.pdf", b"%PDF" + b"x" * 29, "application/pdf")}
+    data = {"account_id": str(sample_account_id)}
+    r = client.post("/ingest/pdf", files=files, data=data)
+    assert r.status_code == 413
+
+
+def test_ingest_pdf_auto_ingest_placeholder_returns_501(client, sample_account_id, monkeypatch):
+    from pfa import main
+
+    row = ParsedCsvRow(
+        transaction_date=datetime.date(2025, 1, 1),
+        posted_date=None,
+        amount=Decimal("-1.00"),
+        currency="USD",
+        description_raw="sample charge",
+    )
+    monkeypatch.setattr(
+        main,
+        "parse_targeted_credit_card_pdf_stub",
+        lambda raw: TargetedPdfParseOutcome(
+            (row,),
+            Decimal("0.95"),
+            "parser_with_rows",
+        ),
+    )
+    files = {"file": ("stmt.pdf", MINIMAL_PDF_BYTES, "application/pdf")}
+    data = {"account_id": str(sample_account_id)}
+    r = client.post("/ingest/pdf", files=files, data=data)
+    assert r.status_code == 501

--- a/backend/tests/test_pdf_ingest_http.py
+++ b/backend/tests/test_pdf_ingest_http.py
@@ -1,0 +1,37 @@
+"""PDF ingest HTTP (slice 12) — integration."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+MINIMAL_PDF_BYTES = b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n1 0 obj<<>>endobj trailer<<>>\n%%EOF\n"
+
+
+def test_ingest_pdf_stub_returns_hitl_gate(client, sample_account_id):
+    files = {"file": ("stmt.pdf", MINIMAL_PDF_BYTES, "application/pdf")}
+    data = {"account_id": str(sample_account_id)}
+    r = client.post("/ingest/pdf", files=files, data=data)
+    assert r.status_code == 200
+    body = r.json()
+    assert body["inserted"] == 0
+    assert body["requires_hitl"] is True
+    assert body["confidence"] == "0.35"
+    assert "stub_parser" in body["parser_notes"]
+
+
+def test_ingest_pdf_rejects_non_pdf(client, sample_account_id):
+    files = {"file": ("not.pdf", b"hello-not-pdf", "application/pdf")}
+    data = {"account_id": str(sample_account_id)}
+    r = client.post("/ingest/pdf", files=files, data=data)
+    assert r.status_code == 422
+
+
+def test_ingest_pdf_unknown_account(client):
+    files = {"file": ("stmt.pdf", MINIMAL_PDF_BYTES, "application/pdf")}
+    data = {"account_id": str(uuid.uuid4())}
+    r = client.post("/ingest/pdf", files=files, data=data)
+    assert r.status_code == 404


### PR DESCRIPTION
Adds POST /ingest/pdf with PDF magic validation, stub targeted CC parser (confidence 0.35, no rows), requires_hitl response, and 501 placeholder when auto-ingest would apply.

Tests: pure pdf_cc rules plus HTTP integration.

Base branch: feat/slice-11-langsmith (merge slice 11 first or retarget main after stack lands).
