### PR TITLE
Slice 2: Ledger bootstrap workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The repo is ahead of the old README in a few areas. Today it contains:
 | CSV statement ingestion | Implemented | Multipart upload with validation, file hashing, account scoping, and transaction dedupe. |
 | Raw statement storage | Implemented | Files are stored on disk using content-addressed paths under the configured upload directory. |
 | Statement purge | Implemented | Removes DB metadata and attempts to delete the stored file. |
+| Ledger bootstrap workflows | Implemented | Institutions, accounts, account aliases, starter categories, and category edits can now be managed through authenticated APIs and the setup UI. |
 | Categories and monthly budgets | Implemented | Category CRUD, budget upsert/list, budget status, and history-based suggestions. |
 | Categorization rules | Implemented | Regex-based rules, retroactive apply option, manual correction, and rule proposal dry runs. |
 | Recurring spend detection | Implemented | Deterministic monthly cadence detection from ledger transactions. |
@@ -34,7 +35,7 @@ The repo is ahead of the old README in a few areas. Today it contains:
 
 ## Product direction
 
-The intended product is a single-user, self-hosted finance application that runs locally by default. A user should be able to upload account statements, build a normalized ledger, manage categories and budgets, inspect recurring spending, and eventually ask an embedded AI agent questions such as why a month was expensive or which subscriptions are driving recurring costs.
+The intended product is a single-user, self-hosted finance application that runs locally by default. A user should be able to authenticate, set up institutions/accounts/categories, upload account statements, build a normalized ledger, manage budgets, inspect recurring spending, and eventually ask an embedded AI agent questions such as why a month was expensive or which subscriptions are driving recurring costs.
 
 The project is deliberately biased toward deterministic behavior:
 
@@ -321,6 +322,8 @@ npm run dev
 
 Open `http://127.0.0.1:5173` and sign in with `PFA_AUTH_USERNAME` / `PFA_AUTH_PASSWORD` from `.env`. The Vite dev server proxies `/api/*` requests to `http://127.0.0.1:8000`, so the browser can keep the session cookie while talking to protected backend routes.
 
+After logging in, open the **Setup** page in the shell to create institutions, accounts, account aliases, and starter categories before using ingestion or analytics workflows.
+
 ### 7. Stop the stack
 
 ```bash
@@ -347,6 +350,7 @@ The repository now includes both backend and frontend validation paths.
 | Categorization | Regex validation, priority ordering, retroactive apply, manual correction, and dry-run proposals. |
 | Recurring detection | Pure recurrence logic and API behavior. |
 | Authentication | Login, logout, session bootstrap, and protected-route enforcement. |
+| Ledger setup | Institution/account/account-alias CRUD plus starter-category bootstrap flows. |
 
 The frontend app-shell tests cover:
 
@@ -391,8 +395,9 @@ The implemented backend is the foundation for a broader product. The PRD calls o
 
 | Planned area | Summary |
 |---|---|
-| Authentication and app shell | Implemented as the first slice; future work deepens the shell into real workflows. |
+| Authentication and app shell | Implemented as the first slice; later slices deepen the shell into ingestion and analytics workflows. |
 | Async jobs and job status | Durable ingestion jobs with step-level progress. |
+| Ledger bootstrap workflows | Implemented through the authenticated setup page and protected setup APIs. |
 | Frontend application | Vite + React + TypeScript client now exists; upload, charts, budgeting, and chat remain to be built on top. |
 | PDF ingestion | Targeted support for selected card statement formats. |
 | Agent and tool layer | Embedded MCP-shaped tools used by a backend-run AI assistant. |

--- a/backend/pfa/budget_api.py
+++ b/backend/pfa/budget_api.py
@@ -13,12 +13,14 @@ from starlette.responses import Response
 
 from pfa.budget_service import (
     BudgetServiceError,
+    bootstrap_default_categories,
     budget_status,
     create_category,
     list_budgets,
     list_categories,
     parse_year_month,
     suggest_budget_amounts,
+    update_category,
     upsert_budgets,
 )
 from pfa.db import connect
@@ -106,6 +108,25 @@ def post_category(body: CategoryCreate):
 def get_categories():
     with connect() as conn:
         rows = list_categories(conn)
+    return [
+        CategoryOut(id=r["id"], slug=r["slug"], name=r["name"]) for r in rows
+    ]
+
+
+@router.put("/categories/{category_id}", status_code=204)
+def put_category(category_id: UUID, body: CategoryCreate):
+    with connect() as conn:
+        try:
+            update_category(conn, category_id, body.slug, body.name)
+        except BudgetServiceError as e:
+            raise _svc_err(e) from e
+    return Response(status_code=204)
+
+
+@router.post("/categories/bootstrap-defaults", response_model=list[CategoryOut])
+def post_bootstrap_default_categories():
+    with connect() as conn:
+        rows = bootstrap_default_categories(conn)
     return [
         CategoryOut(id=r["id"], slug=r["slug"], name=r["name"]) for r in rows
     ]

--- a/backend/pfa/budget_api.py
+++ b/backend/pfa/budget_api.py
@@ -32,7 +32,7 @@ def _svc_err(exc: BudgetServiceError) -> HTTPException:
     msg = str(exc)
     if "already exists" in msg:
         return HTTPException(status_code=409, detail=msg)
-    if "unknown category" in msg:
+    if "unknown category" in msg or "category not found" in msg:
         return HTTPException(status_code=404, detail=msg)
     return HTTPException(status_code=422, detail=msg)
 

--- a/backend/pfa/budget_service.py
+++ b/backend/pfa/budget_service.py
@@ -21,6 +21,18 @@ class BudgetServiceError(ValueError):
     pass
 
 
+DEFAULT_CATEGORY_ROWS: tuple[tuple[str, str], ...] = (
+    ("groceries", "Groceries"),
+    ("rent", "Rent"),
+    ("utilities", "Utilities"),
+    ("transport", "Transport"),
+    ("dining", "Dining"),
+    ("entertainment", "Entertainment"),
+    ("healthcare", "Healthcare"),
+    ("income", "Income"),
+)
+
+
 def parse_year_month(value: str) -> date:
     m = _YEAR_MONTH.fullmatch(value.strip())
     if not m:
@@ -71,12 +83,51 @@ def create_category(conn: psycopg.Connection, slug: str, name: str) -> UUID:
     return UUID(str(row[0]))
 
 
+def update_category(conn: psycopg.Connection, category_id: UUID, slug: str, name: str) -> None:
+    validate_slug(slug)
+    name = name.strip()
+    if not name:
+        raise BudgetServiceError("name is required")
+    try:
+        row = conn.execute(
+            """
+            UPDATE categories
+            SET slug = %s, name = %s
+            WHERE id = %s
+            RETURNING id
+            """,
+            (slug.strip(), name, str(category_id)),
+        ).fetchone()
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise BudgetServiceError("category slug already exists") from exc
+    if row is None:
+        conn.rollback()
+        raise BudgetServiceError("category not found")
+    conn.commit()
+
+
 def list_categories(conn: psycopg.Connection) -> list[dict]:
     with conn.cursor(row_factory=dict_row) as cur:
         cur.execute(
             "SELECT id, slug, name, created_at FROM categories ORDER BY slug ASC"
         )
         return [dict(r) for r in cur.fetchall()]
+
+
+def bootstrap_default_categories(conn: psycopg.Connection) -> list[dict]:
+    with conn.cursor() as cur:
+        for slug, name in DEFAULT_CATEGORY_ROWS:
+            cur.execute(
+                """
+                INSERT INTO categories (slug, name)
+                VALUES (%s, %s)
+                ON CONFLICT (slug) DO UPDATE SET name = EXCLUDED.name
+                """,
+                (slug, name),
+            )
+    conn.commit()
+    return list_categories(conn)
 
 
 def upsert_budgets(

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -31,6 +31,7 @@ from pfa.ingest import (
     update_statement_counts,
 )
 from pfa.pdf_cc import parse_targeted_credit_card_pdf_stub, outcome_requires_hitl
+from pfa.setup_api import router as setup_router
 from pfa.storage import delete_file, sha256_hex, store
 
 MAX_CSV_UPLOAD_BYTES = 10 * 1024 * 1024
@@ -66,6 +67,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(title="Personal Financial Analyst", lifespan=lifespan)
 
 app.include_router(auth_router)
+app.include_router(setup_router, dependencies=[Depends(require_authenticated)])
 app.include_router(budget_router, dependencies=[Depends(require_authenticated)])
 app.include_router(
     categorization_router, dependencies=[Depends(require_authenticated)]

--- a/backend/pfa/schema.sql
+++ b/backend/pfa/schema.sql
@@ -20,6 +20,9 @@ CREATE TABLE IF NOT EXISTS institutions (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE UNIQUE INDEX IF NOT EXISTS idx_institutions_name_unique
+  ON institutions(name);
+
 CREATE TABLE IF NOT EXISTS accounts (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   institution_id UUID NOT NULL REFERENCES institutions(id) ON DELETE CASCADE,
@@ -27,6 +30,9 @@ CREATE TABLE IF NOT EXISTS accounts (
   currency TEXT NOT NULL DEFAULT 'USD',
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_accounts_institution_name_unique
+  ON accounts(institution_id, name);
 
 CREATE TABLE IF NOT EXISTS account_aliases (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/pfa/schema.sql
+++ b/backend/pfa/schema.sql
@@ -28,6 +28,16 @@ CREATE TABLE IF NOT EXISTS accounts (
   created_at TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
+CREATE TABLE IF NOT EXISTS account_aliases (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  account_id UUID NOT NULL REFERENCES accounts(id) ON DELETE CASCADE,
+  alias TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_account_aliases_account_id
+  ON account_aliases(account_id);
+
 -- Slice 5: raw file storage with hash-level idempotency.
 CREATE TABLE IF NOT EXISTS statements (
   id UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/backend/pfa/setup_api.py
+++ b/backend/pfa/setup_api.py
@@ -13,6 +13,8 @@ from pfa.setup_service import (
     create_account,
     create_account_alias,
     create_institution,
+    get_account,
+    get_account_alias,
     list_account_aliases,
     list_accounts,
     list_institutions,
@@ -107,12 +109,11 @@ def post_account(body: AccountBody):
     with connect() as conn:
         try:
             account_id = create_account(conn, body.institution_id, body.name, body.currency)
-            rows = list_accounts(conn)
+            row = get_account(conn, account_id)
         except SetupServiceError as exc:
             raise _setup_error(exc) from exc
-    match = next((row for row in rows if row["id"] == account_id), None)
-    assert match is not None
-    return AccountOut(**match)
+    assert row is not None
+    return AccountOut(**row)
 
 
 @router.put("/accounts/{account_id}", status_code=204)
@@ -142,9 +143,8 @@ def post_account_alias(body: AccountAliasBody):
     with connect() as conn:
         try:
             alias_id = create_account_alias(conn, body.account_id, body.alias)
-            rows = list_account_aliases(conn)
+            row = get_account_alias(conn, alias_id)
         except SetupServiceError as exc:
             raise _setup_error(exc) from exc
-    match = next((row for row in rows if row["id"] == alias_id), None)
-    assert match is not None
-    return AccountAliasOut(**match)
+    assert row is not None
+    return AccountAliasOut(**row)

--- a/backend/pfa/setup_api.py
+++ b/backend/pfa/setup_api.py
@@ -1,0 +1,150 @@
+"""Setup routes for ledger bootstrap workflows."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, ConfigDict, Field
+
+from pfa.db import connect
+from pfa.setup_service import (
+    SetupServiceError,
+    create_account,
+    create_account_alias,
+    create_institution,
+    list_account_aliases,
+    list_accounts,
+    list_institutions,
+    update_account,
+    update_institution,
+)
+
+router = APIRouter(tags=["setup"])
+
+
+def _setup_error(exc: SetupServiceError) -> HTTPException:
+    message = str(exc)
+    if message.endswith("not found"):
+        return HTTPException(status_code=404, detail=message)
+    if "already exists" in message:
+        return HTTPException(status_code=409, detail=message)
+    return HTTPException(status_code=422, detail=message)
+
+
+class InstitutionBody(BaseModel):
+    name: str = Field(min_length=1, max_length=256)
+
+
+class InstitutionOut(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    name: str
+
+
+class AccountBody(BaseModel):
+    institution_id: UUID
+    name: str = Field(min_length=1, max_length=256)
+    currency: str = Field(min_length=1, max_length=8)
+
+
+class AccountOut(BaseModel):
+    id: UUID
+    institution_id: UUID
+    institution_name: str
+    name: str
+    currency: str
+
+
+class AccountAliasBody(BaseModel):
+    account_id: UUID
+    alias: str = Field(min_length=1, max_length=256)
+
+
+class AccountAliasOut(BaseModel):
+    id: UUID
+    account_id: UUID
+    account_name: str
+    alias: str
+
+
+@router.get("/institutions", response_model=list[InstitutionOut])
+def get_institutions():
+    with connect() as conn:
+        rows = list_institutions(conn)
+    return [InstitutionOut(id=row["id"], name=row["name"]) for row in rows]
+
+
+@router.post("/institutions", response_model=InstitutionOut)
+def post_institution(body: InstitutionBody):
+    with connect() as conn:
+        try:
+            institution_id = create_institution(conn, body.name)
+        except SetupServiceError as exc:
+            raise _setup_error(exc) from exc
+    return InstitutionOut(id=institution_id, name=body.name.strip())
+
+
+@router.put("/institutions/{institution_id}", status_code=204)
+def put_institution(institution_id: UUID, body: InstitutionBody):
+    with connect() as conn:
+        try:
+            update_institution(conn, institution_id, body.name)
+        except SetupServiceError as exc:
+            raise _setup_error(exc) from exc
+
+
+@router.get("/accounts", response_model=list[AccountOut])
+def get_accounts():
+    with connect() as conn:
+        rows = list_accounts(conn)
+    return [AccountOut(**row) for row in rows]
+
+
+@router.post("/accounts", response_model=AccountOut)
+def post_account(body: AccountBody):
+    with connect() as conn:
+        try:
+            account_id = create_account(conn, body.institution_id, body.name, body.currency)
+            rows = list_accounts(conn)
+        except SetupServiceError as exc:
+            raise _setup_error(exc) from exc
+    match = next((row for row in rows if row["id"] == account_id), None)
+    assert match is not None
+    return AccountOut(**match)
+
+
+@router.put("/accounts/{account_id}", status_code=204)
+def put_account(account_id: UUID, body: AccountBody):
+    with connect() as conn:
+        try:
+            update_account(
+                conn,
+                account_id,
+                body.institution_id,
+                body.name,
+                body.currency,
+            )
+        except SetupServiceError as exc:
+            raise _setup_error(exc) from exc
+
+
+@router.get("/account-aliases", response_model=list[AccountAliasOut])
+def get_account_aliases():
+    with connect() as conn:
+        rows = list_account_aliases(conn)
+    return [AccountAliasOut(**row) for row in rows]
+
+
+@router.post("/account-aliases", response_model=AccountAliasOut)
+def post_account_alias(body: AccountAliasBody):
+    with connect() as conn:
+        try:
+            alias_id = create_account_alias(conn, body.account_id, body.alias)
+            rows = list_account_aliases(conn)
+        except SetupServiceError as exc:
+            raise _setup_error(exc) from exc
+    match = next((row for row in rows if row["id"] == alias_id), None)
+    assert match is not None
+    return AccountAliasOut(**match)

--- a/backend/pfa/setup_service.py
+++ b/backend/pfa/setup_service.py
@@ -30,10 +30,14 @@ def list_institutions(conn: psycopg.Connection) -> list[dict]:
 
 def create_institution(conn: psycopg.Connection, name: str) -> UUID:
     name = _trim_required(name, field_name="name")
-    row = conn.execute(
-        "INSERT INTO institutions (name) VALUES (%s) RETURNING id",
-        (name,),
-    ).fetchone()
+    try:
+        row = conn.execute(
+            "INSERT INTO institutions (name) VALUES (%s) RETURNING id",
+            (name,),
+        ).fetchone()
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("institution already exists") from exc
     conn.commit()
     assert row is not None
     return UUID(str(row[0]))
@@ -41,10 +45,14 @@ def create_institution(conn: psycopg.Connection, name: str) -> UUID:
 
 def update_institution(conn: psycopg.Connection, institution_id: UUID, name: str) -> None:
     name = _trim_required(name, field_name="name")
-    row = conn.execute(
-        "UPDATE institutions SET name = %s WHERE id = %s RETURNING id",
-        (name, str(institution_id)),
-    ).fetchone()
+    try:
+        row = conn.execute(
+            "UPDATE institutions SET name = %s WHERE id = %s RETURNING id",
+            (name, str(institution_id)),
+        ).fetchone()
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("institution already exists") from exc
     if row is None:
         conn.rollback()
         raise SetupServiceError("institution not found")
@@ -81,9 +89,28 @@ def create_account(
     except pg_errors.ForeignKeyViolation as exc:
         conn.rollback()
         raise SetupServiceError("institution not found") from exc
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("account already exists") from exc
     conn.commit()
     assert row is not None
     return UUID(str(row[0]))
+
+
+def get_account(conn: psycopg.Connection, account_id: UUID) -> dict | None:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT a.id, a.institution_id, i.name AS institution_name, a.name, a.currency
+            FROM accounts a
+            JOIN institutions i ON i.id = a.institution_id
+            WHERE a.id = %s
+            LIMIT 1
+            """,
+            (str(account_id),),
+        )
+        row = cur.fetchone()
+    return dict(row) if row is not None else None
 
 
 def update_account(
@@ -108,6 +135,9 @@ def update_account(
     except pg_errors.ForeignKeyViolation as exc:
         conn.rollback()
         raise SetupServiceError("institution not found") from exc
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("account already exists") from exc
     if row is None:
         conn.rollback()
         raise SetupServiceError("account not found")
@@ -147,3 +177,19 @@ def create_account_alias(conn: psycopg.Connection, account_id: UUID, alias: str)
     conn.commit()
     assert row is not None
     return UUID(str(row[0]))
+
+
+def get_account_alias(conn: psycopg.Connection, alias_id: UUID) -> dict | None:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT aa.id, aa.account_id, a.name AS account_name, aa.alias
+            FROM account_aliases aa
+            JOIN accounts a ON a.id = aa.account_id
+            WHERE aa.id = %s
+            LIMIT 1
+            """,
+            (str(alias_id),),
+        )
+        row = cur.fetchone()
+    return dict(row) if row is not None else None

--- a/backend/pfa/setup_service.py
+++ b/backend/pfa/setup_service.py
@@ -1,0 +1,149 @@
+"""Setup CRUD for institutions, accounts, and account aliases."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import psycopg
+from psycopg import errors as pg_errors
+from psycopg.rows import dict_row
+
+
+class SetupServiceError(ValueError):
+    pass
+
+
+def _trim_required(value: str, *, field_name: str) -> str:
+    trimmed = value.strip()
+    if not trimmed:
+        raise SetupServiceError(f"{field_name} is required")
+    return trimmed
+
+
+def list_institutions(conn: psycopg.Connection) -> list[dict]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            "SELECT id, name, created_at FROM institutions ORDER BY name ASC, created_at ASC"
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_institution(conn: psycopg.Connection, name: str) -> UUID:
+    name = _trim_required(name, field_name="name")
+    row = conn.execute(
+        "INSERT INTO institutions (name) VALUES (%s) RETURNING id",
+        (name,),
+    ).fetchone()
+    conn.commit()
+    assert row is not None
+    return UUID(str(row[0]))
+
+
+def update_institution(conn: psycopg.Connection, institution_id: UUID, name: str) -> None:
+    name = _trim_required(name, field_name="name")
+    row = conn.execute(
+        "UPDATE institutions SET name = %s WHERE id = %s RETURNING id",
+        (name, str(institution_id)),
+    ).fetchone()
+    if row is None:
+        conn.rollback()
+        raise SetupServiceError("institution not found")
+    conn.commit()
+
+
+def list_accounts(conn: psycopg.Connection) -> list[dict]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT a.id, a.institution_id, i.name AS institution_name, a.name, a.currency, a.created_at
+            FROM accounts a
+            JOIN institutions i ON i.id = a.institution_id
+            ORDER BY i.name ASC, a.name ASC, a.created_at ASC
+            """
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_account(
+    conn: psycopg.Connection, institution_id: UUID, name: str, currency: str
+) -> UUID:
+    name = _trim_required(name, field_name="name")
+    currency = _trim_required(currency, field_name="currency").upper()
+    try:
+        row = conn.execute(
+            """
+            INSERT INTO accounts (institution_id, name, currency)
+            VALUES (%s, %s, %s)
+            RETURNING id
+            """,
+            (str(institution_id), name, currency),
+        ).fetchone()
+    except pg_errors.ForeignKeyViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("institution not found") from exc
+    conn.commit()
+    assert row is not None
+    return UUID(str(row[0]))
+
+
+def update_account(
+    conn: psycopg.Connection,
+    account_id: UUID,
+    institution_id: UUID,
+    name: str,
+    currency: str,
+) -> None:
+    name = _trim_required(name, field_name="name")
+    currency = _trim_required(currency, field_name="currency").upper()
+    try:
+        row = conn.execute(
+            """
+            UPDATE accounts
+            SET institution_id = %s, name = %s, currency = %s
+            WHERE id = %s
+            RETURNING id
+            """,
+            (str(institution_id), name, currency, str(account_id)),
+        ).fetchone()
+    except pg_errors.ForeignKeyViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("institution not found") from exc
+    if row is None:
+        conn.rollback()
+        raise SetupServiceError("account not found")
+    conn.commit()
+
+
+def list_account_aliases(conn: psycopg.Connection) -> list[dict]:
+    with conn.cursor(row_factory=dict_row) as cur:
+        cur.execute(
+            """
+            SELECT aa.id, aa.account_id, a.name AS account_name, aa.alias, aa.created_at
+            FROM account_aliases aa
+            JOIN accounts a ON a.id = aa.account_id
+            ORDER BY aa.alias ASC
+            """
+        )
+        return [dict(row) for row in cur.fetchall()]
+
+
+def create_account_alias(conn: psycopg.Connection, account_id: UUID, alias: str) -> UUID:
+    alias = _trim_required(alias, field_name="alias")
+    try:
+        row = conn.execute(
+            """
+            INSERT INTO account_aliases (account_id, alias)
+            VALUES (%s, %s)
+            RETURNING id
+            """,
+            (str(account_id), alias),
+        ).fetchone()
+    except pg_errors.ForeignKeyViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("account not found") from exc
+    except pg_errors.UniqueViolation as exc:
+        conn.rollback()
+        raise SetupServiceError("account alias already exists") from exc
+    conn.commit()
+    assert row is not None
+    return UUID(str(row[0]))

--- a/backend/tests/test_ingest_http.py
+++ b/backend/tests/test_ingest_http.py
@@ -93,10 +93,10 @@ def test_same_file_under_different_account_is_not_a_duplicate(client, clean_db, 
     aid1, aid2 = uuid.uuid4(), uuid.uuid4()
     with clean_db.cursor() as cur:
         cur.execute("INSERT INTO institutions (id, name) VALUES (%s, %s)", (str(iid), "Bank"))
-        for aid in (aid1, aid2):
+        for aid, name in ((aid1, "Checking A"), (aid2, "Checking B")):
             cur.execute(
                 "INSERT INTO accounts (id, institution_id, name, currency) VALUES (%s, %s, %s, %s)",
-                (str(aid), str(iid), "Checking", "USD"),
+                (str(aid), str(iid), name, "USD"),
             )
     clean_db.commit()
 

--- a/backend/tests/test_setup_http.py
+++ b/backend/tests/test_setup_http.py
@@ -1,0 +1,98 @@
+"""Ledger bootstrap HTTP API tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def test_setup_bootstrap_flow(client):
+    institution = client.post("/institutions", json={"name": "Chase"})
+    assert institution.status_code == 200
+    institution_id = institution.json()["id"]
+
+    listed_institutions = client.get("/institutions")
+    assert listed_institutions.status_code == 200
+    assert listed_institutions.json()[0]["name"] == "Chase"
+
+    update_institution = client.put(
+        f"/institutions/{institution_id}",
+        json={"name": "Chase Personal"},
+    )
+    assert update_institution.status_code == 204
+
+    account = client.post(
+        "/accounts",
+        json={
+            "institution_id": institution_id,
+            "name": "Checking",
+            "currency": "usd",
+        },
+    )
+    assert account.status_code == 200
+    account_body = account.json()
+    assert account_body["currency"] == "USD"
+    assert account_body["institution_name"] == "Chase Personal"
+
+    update_account = client.put(
+        f"/accounts/{account_body['id']}",
+        json={
+            "institution_id": institution_id,
+            "name": "Everyday Checking",
+            "currency": "USD",
+        },
+    )
+    assert update_account.status_code == 204
+
+    alias = client.post(
+        "/account-aliases",
+        json={"account_id": account_body["id"], "alias": "Chase Checking"},
+    )
+    assert alias.status_code == 200
+    assert alias.json()["account_name"] == "Everyday Checking"
+
+    aliases = client.get("/account-aliases")
+    assert aliases.status_code == 200
+    assert aliases.json()[0]["alias"] == "Chase Checking"
+
+
+def test_bootstrap_default_categories_and_update_category(client):
+    seeded = client.post("/categories/bootstrap-defaults")
+    assert seeded.status_code == 200
+    rows = seeded.json()
+    assert any(row["slug"] == "groceries" for row in rows)
+
+    groceries = next(row for row in rows if row["slug"] == "groceries")
+    update = client.put(
+        f"/categories/{groceries['id']}",
+        json={"slug": "groceries-home", "name": "Groceries at Home"},
+    )
+    assert update.status_code == 204
+
+    listed = client.get("/categories")
+    assert any(row["slug"] == "groceries-home" for row in listed.json())
+
+
+def test_duplicate_account_alias_conflict(client, clean_db):
+    institution = client.post("/institutions", json={"name": "Local Bank"}).json()
+    account = client.post(
+        "/accounts",
+        json={
+            "institution_id": institution["id"],
+            "name": "Checking",
+            "currency": "USD",
+        },
+    ).json()
+
+    first = client.post(
+        "/account-aliases",
+        json={"account_id": account["id"], "alias": "Main Checking"},
+    )
+    second = client.post(
+        "/account-aliases",
+        json={"account_id": account["id"], "alias": "Main Checking"},
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409

--- a/backend/tests/test_setup_http.py
+++ b/backend/tests/test_setup_http.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import uuid
+
 import pytest
 
 pytestmark = pytest.mark.integration
@@ -96,3 +98,44 @@ def test_duplicate_account_alias_conflict(client, clean_db):
 
     assert first.status_code == 200
     assert second.status_code == 409
+
+
+def test_duplicate_institution_conflict(client):
+    first = client.post("/institutions", json={"name": "Local Bank"})
+    second = client.post("/institutions", json={"name": "Local Bank"})
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+
+
+def test_duplicate_account_within_institution_conflict(client):
+    institution = client.post("/institutions", json={"name": "Local Bank"}).json()
+
+    first = client.post(
+        "/accounts",
+        json={
+            "institution_id": institution["id"],
+            "name": "Checking",
+            "currency": "USD",
+        },
+    )
+    second = client.post(
+        "/accounts",
+        json={
+            "institution_id": institution["id"],
+            "name": "Checking",
+            "currency": "USD",
+        },
+    )
+
+    assert first.status_code == 200
+    assert second.status_code == 409
+
+
+def test_update_unknown_category_returns_404(client):
+    response = client.put(
+        f"/categories/{uuid.uuid4()}",
+        json={"slug": "missing", "name": "Missing"},
+    )
+
+    assert response.status_code == 404

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -147,6 +147,61 @@ button:disabled {
   padding: 1.5rem;
 }
 
+.setup-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+.setup-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(18rem, 1fr));
+  gap: 1rem;
+  margin-top: 1.5rem;
+}
+
+.setup-section {
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  border-radius: 16px;
+  padding: 1rem;
+}
+
+.stacked-form {
+  display: grid;
+  gap: 0.75rem;
+  margin-top: 1rem;
+}
+
+.stacked-form label {
+  display: grid;
+  gap: 0.35rem;
+  color: #e2e8f0;
+  font-weight: 600;
+}
+
+.stacked-form input,
+.stacked-form select {
+  border: 1px solid #334155;
+  border-radius: 10px;
+  background: #020617;
+  color: #f8fafc;
+  padding: 0.75rem 0.85rem;
+  font: inherit;
+}
+
+.simple-list {
+  display: grid;
+  gap: 0.5rem;
+  padding-left: 1.1rem;
+  color: #e2e8f0;
+}
+
+.muted-inline {
+  color: #94a3b8;
+}
+
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -70,4 +70,27 @@ describe('App', () => {
       )
     })
   })
+
+  it('loads the setup workflow for an authenticated session', async () => {
+    mockFetchSequence([
+      { body: { authenticated: true, username: 'admin' } },
+      { body: [] },
+      { body: [] },
+      { body: [] },
+      { body: [] },
+      { body: [] },
+    ])
+
+    render(<App />)
+
+    expect(
+      await screen.findByRole('heading', { name: /authenticated app shell/i }),
+    ).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('link', { name: /setup/i }))
+
+    expect(
+      await screen.findByRole('heading', { name: /ledger bootstrap workflows/i }),
+    ).toBeInTheDocument()
+  })
 })

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
 import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router-dom'
 import { getSession, listCategories, login, logout, type SessionState } from './api'
+import { SetupPage } from './SetupPage'
 import './App.css'
 
 type ProtectedState =
@@ -141,10 +142,12 @@ function Shell({
   session,
   protectedState,
   onLogout,
+  onCategoryCountChange,
 }: {
   session: SessionState
   protectedState: ProtectedState
   onLogout: () => Promise<void>
+  onCategoryCountChange: (count: number) => void
 }) {
   const username = session.username ?? 'admin'
 
@@ -162,10 +165,15 @@ function Shell({
       <div className="shell-body">
         <nav className="shell-nav">
           <Link to="/">Overview</Link>
+          <Link to="/setup">Setup</Link>
           <Link to="/smoke">API smoke</Link>
         </nav>
         <Routes>
           <Route path="/" element={<Overview username={username} protectedState={protectedState} />} />
+          <Route
+            path="/setup"
+            element={<SetupPage onCategoryCountChange={onCategoryCountChange} />}
+          />
           <Route path="/smoke" element={<SmokePage protectedState={protectedState} />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
@@ -250,7 +258,14 @@ function App() {
     <BrowserRouter>
       <main className="app-root">
         {isAuthenticated && session ? (
-          <Shell session={session} protectedState={protectedState} onLogout={handleLogout} />
+          <Shell
+            session={session}
+            protectedState={protectedState}
+            onLogout={handleLogout}
+            onCategoryCountChange={(count) =>
+              setProtectedState({ status: 'ready', categoryCount: count })
+            }
+          />
         ) : (
           <LoginForm onLogin={handleLogin} loading={submitting} />
         )}

--- a/frontend/src/SetupPage.tsx
+++ b/frontend/src/SetupPage.tsx
@@ -1,0 +1,491 @@
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+
+import {
+  bootstrapDefaultCategories,
+  createAccount,
+  createAccountAlias,
+  createCategory,
+  createInstitution,
+  listAccountAliases,
+  listAccounts,
+  listCategories,
+  listInstitutions,
+  updateAccount,
+  updateCategory,
+  updateInstitution,
+  type Account,
+  type AccountAlias,
+  type Category,
+  type Institution,
+} from './api'
+
+type SetupPageProps = {
+  onCategoryCountChange: (count: number) => void
+}
+
+export function SetupPage({ onCategoryCountChange }: SetupPageProps) {
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [institutions, setInstitutions] = useState<Institution[]>([])
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [aliases, setAliases] = useState<AccountAlias[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+
+  const [institutionName, setInstitutionName] = useState('')
+  const [institutionEditId, setInstitutionEditId] = useState('')
+  const [institutionEditName, setInstitutionEditName] = useState('')
+
+  const [accountInstitutionId, setAccountInstitutionId] = useState('')
+  const [accountName, setAccountName] = useState('')
+  const [accountCurrency, setAccountCurrency] = useState('USD')
+  const [accountEditId, setAccountEditId] = useState('')
+  const [accountEditInstitutionId, setAccountEditInstitutionId] = useState('')
+  const [accountEditName, setAccountEditName] = useState('')
+  const [accountEditCurrency, setAccountEditCurrency] = useState('USD')
+
+  const [aliasAccountId, setAliasAccountId] = useState('')
+  const [aliasValue, setAliasValue] = useState('')
+
+  const [categorySlug, setCategorySlug] = useState('')
+  const [categoryName, setCategoryName] = useState('')
+  const [categoryEditId, setCategoryEditId] = useState('')
+  const [categoryEditSlug, setCategoryEditSlug] = useState('')
+  const [categoryEditName, setCategoryEditName] = useState('')
+
+  async function loadSnapshot() {
+    const [nextInstitutions, nextAccounts, nextAliases, nextCategories] =
+      await Promise.all([
+        listInstitutions(),
+        listAccounts(),
+        listAccountAliases(),
+        listCategories(),
+      ])
+
+    setInstitutions(nextInstitutions)
+    setAccounts(nextAccounts)
+    setAliases(nextAliases)
+    setCategories(nextCategories)
+    onCategoryCountChange(nextCategories.length)
+
+    if ((!accountInstitutionId || !nextInstitutions.some((item) => item.id === accountInstitutionId)) && nextInstitutions[0]) {
+      setAccountInstitutionId(nextInstitutions[0].id)
+    }
+    if ((!accountEditInstitutionId || !nextInstitutions.some((item) => item.id === accountEditInstitutionId)) && nextInstitutions[0]) {
+      setAccountEditInstitutionId(nextInstitutions[0].id)
+    }
+    if ((!aliasAccountId || !nextAccounts.some((item) => item.id === aliasAccountId)) && nextAccounts[0]) {
+      setAliasAccountId(nextAccounts[0].id)
+    }
+    if ((!institutionEditId || !nextInstitutions.some((item) => item.id === institutionEditId)) && nextInstitutions[0]) {
+      setInstitutionEditId(nextInstitutions[0].id)
+      setInstitutionEditName(nextInstitutions[0].name)
+    }
+    if ((!accountEditId || !nextAccounts.some((item) => item.id === accountEditId)) && nextAccounts[0]) {
+      setAccountEditId(nextAccounts[0].id)
+      setAccountEditInstitutionId(nextAccounts[0].institution_id)
+      setAccountEditName(nextAccounts[0].name)
+      setAccountEditCurrency(nextAccounts[0].currency)
+    }
+    if ((!categoryEditId || !nextCategories.some((item) => item.id === categoryEditId)) && nextCategories[0]) {
+      setCategoryEditId(nextCategories[0].id)
+      setCategoryEditSlug(nextCategories[0].slug)
+      setCategoryEditName(nextCategories[0].name)
+    }
+  }
+
+  async function refreshAll() {
+    setLoading(true)
+    setError(null)
+    try {
+      await loadSnapshot()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to load setup data')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    async function bootstrap() {
+      try {
+        await loadSnapshot()
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unable to load setup data')
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void bootstrap()
+    // Initial bootstrap only.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function submitAndRefresh(action: () => Promise<unknown>, reset: () => void) {
+    setError(null)
+    try {
+      await action()
+      reset()
+      await refreshAll()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+    }
+  }
+
+  return (
+    <section className="panel">
+      <div className="setup-header">
+        <div>
+          <h2>Ledger bootstrap workflows</h2>
+          <p>
+            Set up institutions, accounts, aliases, and starter categories before
+            ingestion and dashboards build on top of them.
+          </p>
+        </div>
+        <button type="button" className="secondary-button" onClick={() => void refreshAll()}>
+          Refresh
+        </button>
+      </div>
+
+      {error ? <p className="error-banner">{error}</p> : null}
+      {loading ? <p>Loading setup data…</p> : null}
+
+      <div className="setup-grid">
+        <section className="setup-section">
+          <h3>Institutions</h3>
+          <ul className="simple-list">
+            {institutions.map((institution) => (
+              <li key={institution.id}>{institution.name}</li>
+            ))}
+          </ul>
+          <form
+            className="stacked-form"
+            onSubmit={(event: FormEvent<HTMLFormElement>) => {
+              event.preventDefault()
+              void submitAndRefresh(
+                () => createInstitution(institutionName),
+                () => setInstitutionName(''),
+              )
+            }}
+          >
+            <label>
+              New institution
+              <input
+                value={institutionName}
+                onChange={(event) => setInstitutionName(event.target.value)}
+              />
+            </label>
+            <button type="submit" disabled={!institutionName}>
+              Add institution
+            </button>
+          </form>
+          {institutions.length > 0 ? (
+            <form
+              className="stacked-form"
+              onSubmit={(event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault()
+                void submitAndRefresh(
+                  () => updateInstitution(institutionEditId, institutionEditName),
+                  () => undefined,
+                )
+              }}
+            >
+              <label>
+                Edit institution
+                <select
+                  value={institutionEditId}
+                  onChange={(event) => {
+                    const nextId = event.target.value
+                    setInstitutionEditId(nextId)
+                    const match = institutions.find((item) => item.id === nextId)
+                    setInstitutionEditName(match?.name ?? '')
+                  }}
+                >
+                  {institutions.map((institution) => (
+                    <option key={institution.id} value={institution.id}>
+                      {institution.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Updated name
+                <input
+                  value={institutionEditName}
+                  onChange={(event) => setInstitutionEditName(event.target.value)}
+                />
+              </label>
+              <button type="submit" disabled={!institutionEditName}>
+                Save institution
+              </button>
+            </form>
+          ) : null}
+        </section>
+
+        <section className="setup-section">
+          <h3>Accounts</h3>
+          <ul className="simple-list">
+            {accounts.map((account) => (
+              <li key={account.id}>
+                {account.name} — {account.institution_name} ({account.currency})
+              </li>
+            ))}
+          </ul>
+          <form
+            className="stacked-form"
+            onSubmit={(event: FormEvent<HTMLFormElement>) => {
+              event.preventDefault()
+              void submitAndRefresh(
+                () => createAccount(accountInstitutionId, accountName, accountCurrency),
+                () => {
+                  setAccountName('')
+                  setAccountCurrency('USD')
+                },
+              )
+            }}
+          >
+            <label>
+              Institution
+              <select
+                value={accountInstitutionId}
+                onChange={(event) => setAccountInstitutionId(event.target.value)}
+                disabled={institutions.length === 0}
+              >
+                {institutions.map((institution) => (
+                  <option key={institution.id} value={institution.id}>
+                    {institution.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Account name
+              <input value={accountName} onChange={(event) => setAccountName(event.target.value)} />
+            </label>
+            <label>
+              Currency
+              <input
+                value={accountCurrency}
+                onChange={(event) => setAccountCurrency(event.target.value.toUpperCase())}
+              />
+            </label>
+            <button type="submit" disabled={!accountInstitutionId || !accountName}>
+              Add account
+            </button>
+          </form>
+          {accounts.length > 0 ? (
+            <form
+              className="stacked-form"
+              onSubmit={(event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault()
+                void submitAndRefresh(
+                  () =>
+                    updateAccount(
+                      accountEditId,
+                      accountEditInstitutionId,
+                      accountEditName,
+                      accountEditCurrency,
+                    ),
+                  () => undefined,
+                )
+              }}
+            >
+              <label>
+                Edit account
+                <select
+                  value={accountEditId}
+                  onChange={(event) => {
+                    const nextId = event.target.value
+                    setAccountEditId(nextId)
+                    const match = accounts.find((item) => item.id === nextId)
+                    setAccountEditInstitutionId(match?.institution_id ?? '')
+                    setAccountEditName(match?.name ?? '')
+                    setAccountEditCurrency(match?.currency ?? 'USD')
+                  }}
+                >
+                  {accounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Institution
+                <select
+                  value={accountEditInstitutionId}
+                  onChange={(event) => setAccountEditInstitutionId(event.target.value)}
+                >
+                  {institutions.map((institution) => (
+                    <option key={institution.id} value={institution.id}>
+                      {institution.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Updated account name
+                <input
+                  value={accountEditName}
+                  onChange={(event) => setAccountEditName(event.target.value)}
+                />
+              </label>
+              <label>
+                Currency
+                <input
+                  value={accountEditCurrency}
+                  onChange={(event) => setAccountEditCurrency(event.target.value.toUpperCase())}
+                />
+              </label>
+              <button type="submit" disabled={!accountEditName || !accountEditInstitutionId}>
+                Save account
+              </button>
+            </form>
+          ) : null}
+        </section>
+
+        <section className="setup-section">
+          <h3>Account aliases</h3>
+          <ul className="simple-list">
+            {aliases.map((alias) => (
+              <li key={alias.id}>
+                {alias.alias} → {alias.account_name}
+              </li>
+            ))}
+          </ul>
+          <form
+            className="stacked-form"
+            onSubmit={(event: FormEvent<HTMLFormElement>) => {
+              event.preventDefault()
+              void submitAndRefresh(
+                () => createAccountAlias(aliasAccountId, aliasValue),
+                () => setAliasValue(''),
+              )
+            }}
+          >
+            <label>
+              Account
+              <select
+                value={aliasAccountId}
+                onChange={(event) => setAliasAccountId(event.target.value)}
+                disabled={accounts.length === 0}
+              >
+                {accounts.map((account) => (
+                  <option key={account.id} value={account.id}>
+                    {account.name}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              Alias
+              <input value={aliasValue} onChange={(event) => setAliasValue(event.target.value)} />
+            </label>
+            <button type="submit" disabled={!aliasAccountId || !aliasValue}>
+              Add alias
+            </button>
+          </form>
+        </section>
+
+        <section className="setup-section">
+          <h3>Categories</h3>
+          <ul className="simple-list">
+            {categories.map((category) => (
+              <li key={category.id}>
+                {category.name} <span className="muted-inline">({category.slug})</span>
+              </li>
+            ))}
+          </ul>
+          <form
+            className="stacked-form"
+            onSubmit={(event: FormEvent<HTMLFormElement>) => {
+              event.preventDefault()
+              void submitAndRefresh(
+                () => createCategory(categorySlug, categoryName),
+                () => {
+                  setCategorySlug('')
+                  setCategoryName('')
+                },
+              )
+            }}
+          >
+            <label>
+              Category slug
+              <input
+                value={categorySlug}
+                onChange={(event) => setCategorySlug(event.target.value)}
+              />
+            </label>
+            <label>
+              Category name
+              <input
+                value={categoryName}
+                onChange={(event) => setCategoryName(event.target.value)}
+              />
+            </label>
+            <button type="submit" disabled={!categorySlug || !categoryName}>
+              Add category
+            </button>
+          </form>
+          {categories.length > 0 ? (
+            <form
+              className="stacked-form"
+              onSubmit={(event: FormEvent<HTMLFormElement>) => {
+                event.preventDefault()
+                void submitAndRefresh(
+                  () => updateCategory(categoryEditId, categoryEditSlug, categoryEditName),
+                  () => undefined,
+                )
+              }}
+            >
+              <label>
+                Edit category
+                <select
+                  value={categoryEditId}
+                  onChange={(event) => {
+                    const nextId = event.target.value
+                    setCategoryEditId(nextId)
+                    const match = categories.find((item) => item.id === nextId)
+                    setCategoryEditSlug(match?.slug ?? '')
+                    setCategoryEditName(match?.name ?? '')
+                  }}
+                >
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Updated slug
+                <input
+                  value={categoryEditSlug}
+                  onChange={(event) => setCategoryEditSlug(event.target.value)}
+                />
+              </label>
+              <label>
+                Updated name
+                <input
+                  value={categoryEditName}
+                  onChange={(event) => setCategoryEditName(event.target.value)}
+                />
+              </label>
+              <button type="submit" disabled={!categoryEditSlug || !categoryEditName}>
+                Save category
+              </button>
+            </form>
+          ) : null}
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={() => void submitAndRefresh(() => bootstrapDefaultCategories(), () => undefined)}
+          >
+            Load starter categories
+          </button>
+        </section>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,26 @@ export type Category = {
   name: string
 }
 
+export type Institution = {
+  id: string
+  name: string
+}
+
+export type Account = {
+  id: string
+  institution_id: string
+  institution_name: string
+  name: string
+  currency: string
+}
+
+export type AccountAlias = {
+  id: string
+  account_id: string
+  account_name: string
+  alias: string
+}
+
 type RequestOptions = Omit<RequestInit, 'credentials'> & {
   bodyJson?: unknown
 }
@@ -61,4 +81,80 @@ export function logout(): Promise<void> {
 
 export function listCategories(): Promise<Category[]> {
   return request<Category[]>('/categories')
+}
+
+export function createCategory(slug: string, name: string): Promise<Category> {
+  return request<Category>('/categories', {
+    method: 'POST',
+    bodyJson: { slug, name },
+  })
+}
+
+export function updateCategory(id: string, slug: string, name: string): Promise<void> {
+  return request<void>(`/categories/${id}`, {
+    method: 'PUT',
+    bodyJson: { slug, name },
+  })
+}
+
+export function bootstrapDefaultCategories(): Promise<Category[]> {
+  return request<Category[]>('/categories/bootstrap-defaults', {
+    method: 'POST',
+  })
+}
+
+export function listInstitutions(): Promise<Institution[]> {
+  return request<Institution[]>('/institutions')
+}
+
+export function createInstitution(name: string): Promise<Institution> {
+  return request<Institution>('/institutions', {
+    method: 'POST',
+    bodyJson: { name },
+  })
+}
+
+export function updateInstitution(id: string, name: string): Promise<void> {
+  return request<void>(`/institutions/${id}`, {
+    method: 'PUT',
+    bodyJson: { name },
+  })
+}
+
+export function listAccounts(): Promise<Account[]> {
+  return request<Account[]>('/accounts')
+}
+
+export function createAccount(
+  institutionId: string,
+  name: string,
+  currency: string,
+): Promise<Account> {
+  return request<Account>('/accounts', {
+    method: 'POST',
+    bodyJson: { institution_id: institutionId, name, currency },
+  })
+}
+
+export function updateAccount(
+  id: string,
+  institutionId: string,
+  name: string,
+  currency: string,
+): Promise<void> {
+  return request<void>(`/accounts/${id}`, {
+    method: 'PUT',
+    bodyJson: { institution_id: institutionId, name, currency },
+  })
+}
+
+export function listAccountAliases(): Promise<AccountAlias[]> {
+  return request<AccountAlias[]>('/account-aliases')
+}
+
+export function createAccountAlias(accountId: string, alias: string): Promise<AccountAlias> {
+  return request<AccountAlias>('/account-aliases', {
+    method: 'POST',
+    bodyJson: { account_id: accountId, alias },
+  })
 }


### PR DESCRIPTION
## Summary\n- add protected setup APIs for institutions, accounts, account aliases, and starter category bootstrap\n- extend the frontend shell with a setup page for bootstrap CRUD flows\n- add backend integration tests and frontend setup-path coverage\n\n## Testing\n- export DATABASE_URL=postgresql://pfa:pfa_dev_password_change_me@127.0.0.1:5432/pfa && make test-backend\n- cd frontend && npm install && npm run test && npm run build && npm run lint\n\nCloses #4