### PR TITLE
Slice 3: Dashboard and transaction explorer

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The repo is ahead of the old README in a few areas. Today it contains:
 | Raw statement storage | Implemented | Files are stored on disk using content-addressed paths under the configured upload directory. |
 | Statement purge | Implemented | Removes DB metadata and attempts to delete the stored file. |
 | Ledger bootstrap workflows | Implemented | Institutions, accounts, account aliases, starter categories, and category edits can now be managed through authenticated APIs and the setup UI. |
+| Dashboard and transaction explorer | Implemented | Manual transactions can seed the ledger, dashboard aggregates show cashflow/category spend over time, and a transaction explorer supports filtering. |
 | Categories and monthly budgets | Implemented | Category CRUD, budget upsert/list, budget status, and history-based suggestions. |
 | Categorization rules | Implemented | Regex-based rules, retroactive apply option, manual correction, and rule proposal dry runs. |
 | Recurring spend detection | Implemented | Deterministic monthly cadence detection from ledger transactions. |
@@ -322,7 +323,11 @@ npm run dev
 
 Open `http://127.0.0.1:5173` and sign in with `PFA_AUTH_USERNAME` / `PFA_AUTH_PASSWORD` from `.env`. The Vite dev server proxies `/api/*` requests to `http://127.0.0.1:8000`, so the browser can keep the session cookie while talking to protected backend routes.
 
-After logging in, open the **Setup** page in the shell to create institutions, accounts, account aliases, and starter categories before using ingestion or analytics workflows.
+After logging in:
+
+- open **Setup** to create institutions, accounts, account aliases, and starter categories;
+- open **Transactions** to add sample manual transactions before ingestion is ready;
+- use the default **Dashboard** route to view cashflow and category-spend summaries.
 
 ### 7. Stop the stack
 
@@ -346,6 +351,7 @@ The repository now includes both backend and frontend validation paths.
 | Dedupe logic | Fingerprint behavior and duplicate handling. |
 | File storage | Hash generation, content-addressed storage, and file deletion behavior. |
 | Ingestion HTTP flow | Upload validation, idempotency, unknown-account handling, and purge behavior. |
+| Dashboard and explorer | Manual transaction entry, dashboard cashflow/category views, and filtered transaction listing. |
 | Budgeting | Category creation, budget upsert/list, projections, and suggestions. |
 | Categorization | Regex validation, priority ordering, retroactive apply, manual correction, and dry-run proposals. |
 | Recurring detection | Pure recurrence logic and API behavior. |
@@ -398,7 +404,7 @@ The implemented backend is the foundation for a broader product. The PRD calls o
 | Authentication and app shell | Implemented as the first slice; later slices deepen the shell into ingestion and analytics workflows. |
 | Async jobs and job status | Durable ingestion jobs with step-level progress. |
 | Ledger bootstrap workflows | Implemented through the authenticated setup page and protected setup APIs. |
-| Frontend application | Vite + React + TypeScript client now exists; upload, charts, budgeting, and chat remain to be built on top. |
+| Frontend application | Vite + React + TypeScript client now includes login, setup, dashboard, and transaction explorer; upload, budgeting, and chat remain to be built on top. |
 | PDF ingestion | Targeted support for selected card statement formats. |
 | Agent and tool layer | Embedded MCP-shaped tools used by a backend-run AI assistant. |
 | Observability | LangSmith tracing for agent and tool execution. |

--- a/backend/pfa/dashboard_api.py
+++ b/backend/pfa/dashboard_api.py
@@ -1,0 +1,84 @@
+"""Dashboard aggregate routes."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+
+from fastapi import APIRouter, Query
+from psycopg.rows import dict_row
+from pydantic import BaseModel, Field
+
+from pfa.db import connect
+
+router = APIRouter(prefix="/dashboard", tags=["dashboard"])
+
+
+def _month_window(months: int) -> tuple[date, date]:
+    if months < 1:
+        raise ValueError("months must be >= 1")
+    today = date.today()
+    y = today.year
+    m = today.month - (months - 1)
+    while m <= 0:
+        m += 12
+        y -= 1
+    return date(y, m, 1), today
+
+
+class CashflowPoint(BaseModel):
+    month: date
+    income_total: Decimal
+    expense_total_abs: Decimal
+    net_total: Decimal
+
+
+class CategorySpendPoint(BaseModel):
+    month: date
+    category_id: str | None
+    category_name: str
+    spend_total: Decimal
+
+
+@router.get("/cashflow", response_model=list[CashflowPoint])
+def get_cashflow(months: int = Query(default=6, ge=1, le=60)):
+    start_date, end_date = _month_window(months)
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT date_trunc('month', transaction_date)::date AS month,
+                       COALESCE(SUM(CASE WHEN amount > 0 THEN amount ELSE 0 END), 0) AS income_total,
+                       COALESCE(SUM(CASE WHEN amount < 0 THEN -amount ELSE 0 END), 0) AS expense_total_abs,
+                       COALESCE(SUM(amount), 0) AS net_total
+                FROM transactions
+                WHERE transaction_date >= %s AND transaction_date <= %s
+                GROUP BY month
+                ORDER BY month ASC
+                """,
+                (start_date, end_date),
+            )
+            return [CashflowPoint(**dict(row)) for row in cur.fetchall()]
+
+
+@router.get("/category-spend", response_model=list[CategorySpendPoint])
+def get_category_spend(months: int = Query(default=6, ge=1, le=60)):
+    start_date, end_date = _month_window(months)
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT date_trunc('month', t.transaction_date)::date AS month,
+                       t.category_id::text AS category_id,
+                       COALESCE(c.name, 'Uncategorized') AS category_name,
+                       COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END), 0) AS spend_total
+                FROM transactions t
+                LEFT JOIN categories c ON c.id = t.category_id
+                WHERE t.transaction_date >= %s AND t.transaction_date <= %s
+                GROUP BY month, t.category_id, category_name
+                HAVING COALESCE(SUM(CASE WHEN t.amount < 0 THEN -t.amount ELSE 0 END), 0) > 0
+                ORDER BY month ASC, category_name ASC
+                """,
+                (start_date, end_date),
+            )
+            return [CategorySpendPoint(**dict(row)) for row in cur.fetchall()]

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -15,6 +15,7 @@ from pydantic import BaseModel
 from pfa.anomalies_api import router as anomalies_router
 from pfa.auth import require_authenticated
 from pfa.auth_api import router as auth_router
+from pfa.dashboard_api import router as dashboard_router
 from pfa.budget_api import router as budget_router
 from pfa.chat_api import router as chat_router
 from pfa.categorization_api import router as categorization_router
@@ -33,6 +34,7 @@ from pfa.ingest import (
 from pfa.pdf_cc import parse_targeted_credit_card_pdf_stub, outcome_requires_hitl
 from pfa.setup_api import router as setup_router
 from pfa.storage import delete_file, sha256_hex, store
+from pfa.transactions_api import router as transactions_router
 
 MAX_CSV_UPLOAD_BYTES = 10 * 1024 * 1024
 MAX_PDF_UPLOAD_BYTES = MAX_CSV_UPLOAD_BYTES
@@ -68,6 +70,8 @@ app = FastAPI(title="Personal Financial Analyst", lifespan=lifespan)
 
 app.include_router(auth_router)
 app.include_router(setup_router, dependencies=[Depends(require_authenticated)])
+app.include_router(dashboard_router, dependencies=[Depends(require_authenticated)])
+app.include_router(transactions_router, dependencies=[Depends(require_authenticated)])
 app.include_router(budget_router, dependencies=[Depends(require_authenticated)])
 app.include_router(
     categorization_router, dependencies=[Depends(require_authenticated)]

--- a/backend/pfa/transactions_api.py
+++ b/backend/pfa/transactions_api.py
@@ -1,0 +1,189 @@
+"""Manual transaction entry and explorer routes."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+from psycopg import errors as pg_errors
+from psycopg.rows import dict_row
+from pydantic import BaseModel, Field
+
+from pfa.db import connect
+from pfa.dedupe import normalize_description, transaction_fingerprint
+
+router = APIRouter(tags=["transactions"])
+
+
+class TransactionCreate(BaseModel):
+    account_id: UUID
+    transaction_date: date
+    posted_date: date | None = None
+    amount: Decimal
+    currency: str = Field(default="USD", min_length=1, max_length=8)
+    description: str = Field(min_length=1, max_length=512)
+    category_id: UUID | None = None
+
+
+class TransactionOut(BaseModel):
+    id: UUID
+    account_id: UUID
+    account_name: str
+    institution_name: str
+    transaction_date: date
+    posted_date: date | None
+    amount: Decimal
+    currency: str
+    description_raw: str
+    category_id: UUID | None
+    category_name: str | None
+
+
+def _ensure_account_exists(conn, account_id: UUID) -> None:
+    row = conn.execute("SELECT 1 FROM accounts WHERE id = %s", (str(account_id),)).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="account not found")
+
+
+def _ensure_category_exists(conn, category_id: UUID | None) -> None:
+    if category_id is None:
+        return
+    row = conn.execute("SELECT 1 FROM categories WHERE id = %s", (str(category_id),)).fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="category not found")
+
+
+def _list_transactions(
+    *,
+    account_id: UUID | None = None,
+    category_id: UUID | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    q: str | None = None,
+    limit: int = 100,
+) -> list[dict]:
+    sql = """
+        SELECT t.id, t.account_id, a.name AS account_name, i.name AS institution_name,
+               t.transaction_date, t.posted_date, t.amount, t.currency,
+               t.description_raw, t.category_id, c.name AS category_name
+        FROM transactions t
+        JOIN accounts a ON a.id = t.account_id
+        JOIN institutions i ON i.id = a.institution_id
+        LEFT JOIN categories c ON c.id = t.category_id
+        WHERE 1 = 1
+    """
+    params: list[object] = []
+    if account_id is not None:
+        sql += " AND t.account_id = %s"
+        params.append(str(account_id))
+    if category_id is not None:
+        sql += " AND t.category_id = %s"
+        params.append(str(category_id))
+    if start_date is not None:
+        sql += " AND t.transaction_date >= %s"
+        params.append(start_date)
+    if end_date is not None:
+        sql += " AND t.transaction_date <= %s"
+        params.append(end_date)
+    if q:
+        sql += " AND t.description_raw ILIKE %s"
+        params.append(f"%{q.strip()}%")
+    sql += " ORDER BY t.transaction_date DESC, t.created_at DESC LIMIT %s"
+    params.append(limit)
+
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(sql, tuple(params))
+            return [dict(row) for row in cur.fetchall()]
+
+
+def _get_transaction_by_id(transaction_id: UUID) -> dict:
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT t.id, t.account_id, a.name AS account_name, i.name AS institution_name,
+                       t.transaction_date, t.posted_date, t.amount, t.currency,
+                       t.description_raw, t.category_id, c.name AS category_name
+                FROM transactions t
+                JOIN accounts a ON a.id = t.account_id
+                JOIN institutions i ON i.id = a.institution_id
+                LEFT JOIN categories c ON c.id = t.category_id
+                WHERE t.id = %s
+                LIMIT 1
+                """,
+                (str(transaction_id),),
+            )
+            row = cur.fetchone()
+    assert row is not None
+    return dict(row)
+
+
+@router.get("/transactions", response_model=list[TransactionOut])
+def get_transactions(
+    account_id: UUID | None = None,
+    category_id: UUID | None = None,
+    start_date: date | None = None,
+    end_date: date | None = None,
+    q: str | None = Query(default=None, max_length=256),
+    limit: int = Query(default=100, ge=1, le=500),
+):
+    rows = _list_transactions(
+        account_id=account_id,
+        category_id=category_id,
+        start_date=start_date,
+        end_date=end_date,
+        q=q,
+        limit=limit,
+    )
+    return [TransactionOut(**row) for row in rows]
+
+
+@router.post("/transactions", response_model=TransactionOut)
+def post_transaction(body: TransactionCreate):
+    desc_norm = normalize_description(body.description)
+    fp = transaction_fingerprint(
+        body.account_id,
+        body.transaction_date,
+        body.amount,
+        desc_norm,
+    )
+    with connect() as conn:
+        _ensure_account_exists(conn, body.account_id)
+        _ensure_category_exists(conn, body.category_id)
+        try:
+            row = conn.execute(
+                """
+                INSERT INTO transactions (
+                  account_id,
+                  transaction_date,
+                  posted_date,
+                  amount,
+                  currency,
+                  description_raw,
+                  description_normalized,
+                  dedupe_fingerprint,
+                  category_id
+                ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s)
+                RETURNING id
+                """,
+                (
+                    str(body.account_id),
+                    body.transaction_date,
+                    body.posted_date,
+                    body.amount,
+                    body.currency.upper(),
+                    body.description.strip(),
+                    desc_norm,
+                    fp,
+                    str(body.category_id) if body.category_id else None,
+                ),
+            ).fetchone()
+        except pg_errors.UniqueViolation as exc:
+            conn.rollback()
+            raise HTTPException(status_code=409, detail="transaction already exists") from exc
+        conn.commit()
+    assert row is not None
+    return TransactionOut(**_get_transaction_by_id(row[0]))

--- a/backend/tests/test_dashboard_http.py
+++ b/backend/tests/test_dashboard_http.py
@@ -1,0 +1,88 @@
+"""Dashboard and transaction explorer API tests."""
+
+from __future__ import annotations
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+
+def _create_setup(client):
+    institution = client.post("/institutions", json={"name": "Demo Bank"}).json()
+    category = client.post("/categories", json={"slug": "groceries", "name": "Groceries"}).json()
+    account = client.post(
+        "/accounts",
+        json={
+            "institution_id": institution["id"],
+            "name": "Checking",
+            "currency": "USD",
+        },
+    ).json()
+    return account, category
+
+
+def test_manual_transactions_drive_dashboard_and_explorer(client):
+    account, category = _create_setup(client)
+
+    first = client.post(
+        "/transactions",
+        json={
+            "account_id": account["id"],
+            "transaction_date": "2025-04-05",
+            "amount": "-42.50",
+            "currency": "USD",
+            "description": "Whole Foods",
+            "category_id": category["id"],
+        },
+    )
+    assert first.status_code == 200
+
+    second = client.post(
+        "/transactions",
+        json={
+            "account_id": account["id"],
+            "transaction_date": "2025-04-10",
+            "amount": "1500.00",
+            "currency": "USD",
+            "description": "Salary",
+        },
+    )
+    assert second.status_code == 200
+
+    listed = client.get("/transactions", params={"q": "Whole", "limit": 10})
+    assert listed.status_code == 200
+    rows = listed.json()
+    assert len(rows) == 1
+    assert rows[0]["description_raw"] == "Whole Foods"
+    assert rows[0]["category_name"] == "Groceries"
+
+    cashflow = client.get("/dashboard/cashflow", params={"months": 24})
+    assert cashflow.status_code == 200
+    cashflow_rows = cashflow.json()
+    assert any(row["income_total"] == "1500.0000" for row in cashflow_rows)
+    assert any(row["expense_total_abs"] == "42.5000" for row in cashflow_rows)
+
+    category_spend = client.get("/dashboard/category-spend", params={"months": 24})
+    assert category_spend.status_code == 200
+    spend_rows = category_spend.json()
+    assert len(spend_rows) == 1
+    assert spend_rows[0]["category_name"] == "Groceries"
+    assert spend_rows[0]["spend_total"] == "42.5000"
+
+
+def test_duplicate_manual_transaction_conflict(client):
+    account, category = _create_setup(client)
+    payload = {
+        "account_id": account["id"],
+        "transaction_date": "2025-04-05",
+        "amount": "-42.50",
+        "currency": "USD",
+        "description": "Whole Foods",
+        "category_id": category["id"],
+    }
+
+    first = client.post("/transactions", json=payload)
+    second = client.post("/transactions", json=payload)
+
+    assert first.status_code == 200
+    assert second.status_code == 409

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -202,6 +202,20 @@ button:disabled {
   color: #94a3b8;
 }
 
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+}
+
+.data-table th,
+.data-table td {
+  text-align: left;
+  padding: 0.7rem 0.6rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+  color: #e2e8f0;
+}
+
 .status-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));

--- a/frontend/src/App.test.tsx
+++ b/frontend/src/App.test.tsx
@@ -42,6 +42,8 @@ describe('App', () => {
       { body: { authenticated: false, username: null } },
       { body: { authenticated: true, username: 'admin' } },
       { body: [] },
+      { body: [] },
+      { body: [] },
     ])
 
     render(<App />)
@@ -55,10 +57,9 @@ describe('App', () => {
     fireEvent.click(screen.getByRole('button', { name: /sign in/i }))
 
     expect(
-      await screen.findByRole('heading', { name: /authenticated app shell/i }),
+      await screen.findByRole('heading', { name: /dashboard/i }),
     ).toBeInTheDocument()
-    expect(await screen.findByText(/^Reachable$/)).toBeInTheDocument()
-    expect(await screen.findByText(/^0$/)).toBeInTheDocument()
+    expect(await screen.findByText(/cashflow over time/i)).toBeInTheDocument()
 
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
@@ -79,12 +80,15 @@ describe('App', () => {
       { body: [] },
       { body: [] },
       { body: [] },
+      { body: [] },
+      { body: [] },
+      { body: [] },
     ])
 
     render(<App />)
 
     expect(
-      await screen.findByRole('heading', { name: /authenticated app shell/i }),
+      await screen.findByRole('heading', { name: /dashboard/i }),
     ).toBeInTheDocument()
 
     fireEvent.click(screen.getByRole('link', { name: /setup/i }))

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,7 +2,9 @@ import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
 import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router-dom'
 import { getSession, listCategories, login, logout, type SessionState } from './api'
+import { DashboardPage } from './DashboardPage'
 import { SetupPage } from './SetupPage'
+import { TransactionsPage } from './TransactionsPage'
 import './App.css'
 
 type ProtectedState =
@@ -68,49 +70,11 @@ function LoginForm({
   )
 }
 
-function Overview({
-  username,
-  protectedState,
-}: {
-  username: string
-  protectedState: ProtectedState
-}) {
+function Overview({ username }: { username: string }) {
   return (
     <section className="panel">
       <h2>Welcome back, {username}</h2>
-      <p>
-        This first shell proves the frontend can authenticate, keep a session,
-        and reach protected backend APIs.
-      </p>
-      <div className="status-grid">
-        <article>
-          <span className="metric-label">Session</span>
-          <strong>Authenticated</strong>
-        </article>
-        <article>
-          <span className="metric-label">Protected API</span>
-          <strong>
-            {protectedState.status === 'ready'
-              ? 'Reachable'
-              : protectedState.status === 'error'
-                ? 'Failed'
-                : protectedState.status === 'loading'
-                  ? 'Loading…'
-                  : 'Not started'}
-          </strong>
-        </article>
-        <article>
-          <span className="metric-label">Categories</span>
-          <strong>
-            {protectedState.status === 'ready'
-              ? protectedState.categoryCount
-              : '—'}
-          </strong>
-        </article>
-      </div>
-      {protectedState.status === 'error' ? (
-        <p className="error-banner">{protectedState.message}</p>
-      ) : null}
+      <p>The dashboard and transaction explorer are now available in the app shell.</p>
     </section>
   )
 }
@@ -164,16 +128,23 @@ function Shell({
       </header>
       <div className="shell-body">
         <nav className="shell-nav">
-          <Link to="/">Overview</Link>
+          <Link to="/">Dashboard</Link>
           <Link to="/setup">Setup</Link>
+          <Link to="/transactions">Transactions</Link>
           <Link to="/smoke">API smoke</Link>
         </nav>
         <Routes>
-          <Route path="/" element={<Overview username={username} protectedState={protectedState} />} />
+          <Route path="/" element={<DashboardPage onError={(message) => {
+            if (message) {
+              onCategoryCountChange(0)
+            }
+          }} />} />
+          <Route path="/overview" element={<Overview username={username} />} />
           <Route
             path="/setup"
             element={<SetupPage onCategoryCountChange={onCategoryCountChange} />}
           />
+          <Route path="/transactions" element={<TransactionsPage onError={() => undefined} />} />
           <Route path="/smoke" element={<SmokePage protectedState={protectedState} />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>

--- a/frontend/src/DashboardPage.tsx
+++ b/frontend/src/DashboardPage.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useState } from 'react'
+
+import { listCashflow, listCategorySpend, type DashboardCashflowPoint, type DashboardCategorySpendPoint } from './api'
+
+type DashboardPageProps = {
+  onError: (message: string | null) => void
+}
+
+export function DashboardPage({ onError }: DashboardPageProps) {
+  const [cashflow, setCashflow] = useState<DashboardCashflowPoint[]>([])
+  const [categorySpend, setCategorySpend] = useState<DashboardCategorySpendPoint[]>([])
+  const [loading, setLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        const [nextCashflow, nextCategorySpend] = await Promise.all([
+          listCashflow(12),
+          listCategorySpend(12),
+        ])
+        if (cancelled) {
+          return
+        }
+        setCashflow(nextCashflow)
+        setCategorySpend(nextCategorySpend)
+        onError(null)
+      } catch (error) {
+        if (!cancelled) {
+          onError(error instanceof Error ? error.message : 'Unable to load dashboard data')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+  }, [onError])
+
+  if (loading) {
+    return <section className="panel"><p>Loading dashboard…</p></section>
+  }
+
+  return (
+    <section className="panel">
+      <h2>Dashboard</h2>
+      <p>Cashflow and category spend light up as soon as you create or import transactions.</p>
+
+      <div className="status-grid">
+        <article>
+          <span className="metric-label">Cashflow months</span>
+          <strong>{cashflow.length}</strong>
+        </article>
+        <article>
+          <span className="metric-label">Category spend rows</span>
+          <strong>{categorySpend.length}</strong>
+        </article>
+      </div>
+
+      <div className="setup-grid">
+        <section className="setup-section">
+          <h3>Cashflow over time</h3>
+          {cashflow.length === 0 ? (
+            <p>Add manual transactions from the explorer to populate this view.</p>
+          ) : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Month</th>
+                  <th>Income</th>
+                  <th>Expenses</th>
+                  <th>Net</th>
+                </tr>
+              </thead>
+              <tbody>
+                {cashflow.map((row) => (
+                  <tr key={row.month}>
+                    <td>{row.month}</td>
+                    <td>{row.income_total}</td>
+                    <td>{row.expense_total_abs}</td>
+                    <td>{row.net_total}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+
+        <section className="setup-section">
+          <h3>Category spending over time</h3>
+          {categorySpend.length === 0 ? (
+            <p>Create categorized manual transactions to populate this view.</p>
+          ) : (
+            <table className="data-table">
+              <thead>
+                <tr>
+                  <th>Month</th>
+                  <th>Category</th>
+                  <th>Spend</th>
+                </tr>
+              </thead>
+              <tbody>
+                {categorySpend.map((row) => (
+                  <tr key={`${row.month}-${row.category_name}`}>
+                    <td>{row.month}</td>
+                    <td>{row.category_name}</td>
+                    <td>{row.spend_total}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </section>
+      </div>
+    </section>
+  )
+}

--- a/frontend/src/TransactionsPage.tsx
+++ b/frontend/src/TransactionsPage.tsx
@@ -1,0 +1,214 @@
+import { useEffect, useState } from 'react'
+import type { FormEvent } from 'react'
+
+import {
+  createTransaction,
+  listAccounts,
+  listCategories,
+  listTransactions,
+  type Account,
+  type Category,
+  type Transaction,
+} from './api'
+
+type TransactionsPageProps = {
+  onError: (message: string | null) => void
+}
+
+export function TransactionsPage({ onError }: TransactionsPageProps) {
+  const [accounts, setAccounts] = useState<Account[]>([])
+  const [categories, setCategories] = useState<Category[]>([])
+  const [transactions, setTransactions] = useState<Transaction[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const [accountId, setAccountId] = useState('')
+  const [categoryId, setCategoryId] = useState('')
+  const [description, setDescription] = useState('')
+  const [amount, setAmount] = useState('')
+  const [transactionDate, setTransactionDate] = useState('')
+  const [searchText, setSearchText] = useState('')
+
+  async function refreshExplorer() {
+    const [nextAccounts, nextCategories, nextTransactions] = await Promise.all([
+      listAccounts(),
+      listCategories(),
+      listTransactions({ q: searchText || undefined, limit: 50 }),
+    ])
+    setAccounts(nextAccounts)
+    setCategories(nextCategories)
+    setTransactions(nextTransactions)
+    if (!accountId && nextAccounts[0]) {
+      setAccountId(nextAccounts[0].id)
+    }
+    if (!categoryId && nextCategories[0]) {
+      setCategoryId(nextCategories[0].id)
+    }
+  }
+
+  useEffect(() => {
+    let cancelled = false
+
+    async function load() {
+      try {
+        await refreshExplorer()
+        if (!cancelled) {
+          onError(null)
+        }
+      } catch (error) {
+        if (!cancelled) {
+          onError(error instanceof Error ? error.message : 'Unable to load transactions')
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false)
+        }
+      }
+    }
+
+    void load()
+    return () => {
+      cancelled = true
+    }
+    // searchText is user-triggered through the filter form.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  async function handleCreate(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    try {
+      await createTransaction({
+        accountId,
+        transactionDate,
+        amount,
+        currency: 'USD',
+        description,
+        categoryId: categoryId || undefined,
+      })
+      setDescription('')
+      setAmount('')
+      setTransactionDate('')
+      await refreshExplorer()
+      onError(null)
+    } catch (error) {
+      onError(error instanceof Error ? error.message : 'Unable to create transaction')
+    }
+  }
+
+  async function handleFilter(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault()
+    try {
+      setTransactions(await listTransactions({ q: searchText || undefined, limit: 50 }))
+      onError(null)
+    } catch (error) {
+      onError(error instanceof Error ? error.message : 'Unable to filter transactions')
+    }
+  }
+
+  return (
+    <section className="panel">
+      <h2>Transaction explorer</h2>
+      <p>
+        Enter sample transactions manually before async ingestion is ready, then
+        filter and inspect them here.
+      </p>
+
+      <div className="setup-grid">
+        <section className="setup-section">
+          <h3>Add manual transaction</h3>
+          {accounts.length === 0 ? (
+            <p>Create an institution and account in Setup before adding transactions.</p>
+          ) : (
+            <form className="stacked-form" onSubmit={handleCreate}>
+              <label>
+                Account
+                <select value={accountId} onChange={(event) => setAccountId(event.target.value)}>
+                  {accounts.map((account) => (
+                    <option key={account.id} value={account.id}>
+                      {account.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Category
+                <select value={categoryId} onChange={(event) => setCategoryId(event.target.value)}>
+                  <option value="">Uncategorized</option>
+                  {categories.map((category) => (
+                    <option key={category.id} value={category.id}>
+                      {category.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+              <label>
+                Description
+                <input
+                  value={description}
+                  onChange={(event) => setDescription(event.target.value)}
+                />
+              </label>
+              <label>
+                Amount
+                <input value={amount} onChange={(event) => setAmount(event.target.value)} />
+              </label>
+              <label>
+                Transaction date
+                <input
+                  type="date"
+                  value={transactionDate}
+                  onChange={(event) => setTransactionDate(event.target.value)}
+                />
+              </label>
+              <button type="submit" disabled={!accountId || !description || !amount || !transactionDate}>
+                Save transaction
+              </button>
+            </form>
+          )}
+        </section>
+
+        <section className="setup-section">
+          <h3>Filter transactions</h3>
+          <form className="stacked-form" onSubmit={handleFilter}>
+            <label>
+              Search description
+              <input value={searchText} onChange={(event) => setSearchText(event.target.value)} />
+            </label>
+            <button type="submit">Apply filter</button>
+          </form>
+        </section>
+      </div>
+
+      {loading ? (
+        <p>Loading transactions…</p>
+      ) : transactions.length === 0 ? (
+        <p>No transactions yet. Add one manually to seed the dashboard.</p>
+      ) : (
+        <table className="data-table">
+          <thead>
+            <tr>
+              <th>Date</th>
+              <th>Description</th>
+              <th>Account</th>
+              <th>Category</th>
+              <th>Amount</th>
+            </tr>
+          </thead>
+          <tbody>
+            {transactions.map((transaction) => (
+              <tr key={transaction.id}>
+                <td>{transaction.transaction_date}</td>
+                <td>{transaction.description_raw}</td>
+                <td>
+                  {transaction.account_name}
+                  <div className="muted-inline">{transaction.institution_name}</div>
+                </td>
+                <td>{transaction.category_name ?? 'Uncategorized'}</td>
+                <td>{transaction.amount}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -29,6 +29,34 @@ export type AccountAlias = {
   alias: string
 }
 
+export type DashboardCashflowPoint = {
+  month: string
+  income_total: string
+  expense_total_abs: string
+  net_total: string
+}
+
+export type DashboardCategorySpendPoint = {
+  month: string
+  category_id: string | null
+  category_name: string
+  spend_total: string
+}
+
+export type Transaction = {
+  id: string
+  account_id: string
+  account_name: string
+  institution_name: string
+  transaction_date: string
+  posted_date: string | null
+  amount: string
+  currency: string
+  description_raw: string
+  category_id: string | null
+  category_name: string | null
+}
+
 type RequestOptions = Omit<RequestInit, 'credentials'> & {
   bodyJson?: unknown
 }
@@ -156,5 +184,69 @@ export function createAccountAlias(accountId: string, alias: string): Promise<Ac
   return request<AccountAlias>('/account-aliases', {
     method: 'POST',
     bodyJson: { account_id: accountId, alias },
+  })
+}
+
+export function listCashflow(months = 6): Promise<DashboardCashflowPoint[]> {
+  return request<DashboardCashflowPoint[]>(`/dashboard/cashflow?months=${months}`)
+}
+
+export function listCategorySpend(months = 6): Promise<DashboardCategorySpendPoint[]> {
+  return request<DashboardCategorySpendPoint[]>(
+    `/dashboard/category-spend?months=${months}`,
+  )
+}
+
+export function listTransactions(params?: {
+  accountId?: string
+  categoryId?: string
+  q?: string
+  startDate?: string
+  endDate?: string
+  limit?: number
+}): Promise<Transaction[]> {
+  const search = new URLSearchParams()
+  if (params?.accountId) {
+    search.set('account_id', params.accountId)
+  }
+  if (params?.categoryId) {
+    search.set('category_id', params.categoryId)
+  }
+  if (params?.q) {
+    search.set('q', params.q)
+  }
+  if (params?.startDate) {
+    search.set('start_date', params.startDate)
+  }
+  if (params?.endDate) {
+    search.set('end_date', params.endDate)
+  }
+  if (params?.limit) {
+    search.set('limit', String(params.limit))
+  }
+  const suffix = search.toString()
+  return request<Transaction[]>(`/transactions${suffix ? `?${suffix}` : ''}`)
+}
+
+export function createTransaction(body: {
+  accountId: string
+  transactionDate: string
+  postedDate?: string
+  amount: string
+  currency: string
+  description: string
+  categoryId?: string
+}): Promise<Transaction> {
+  return request<Transaction>('/transactions', {
+    method: 'POST',
+    bodyJson: {
+      account_id: body.accountId,
+      transaction_date: body.transactionDate,
+      posted_date: body.postedDate || null,
+      amount: body.amount,
+      currency: body.currency,
+      description: body.description,
+      category_id: body.categoryId || null,
+    },
   })
 }


### PR DESCRIPTION
## Summary\n- add protected dashboard aggregates for cashflow and category spend over time\n- add manual transaction entry plus filtered transaction explorer APIs\n- wire dashboard and explorer pages into the frontend shell with coverage and docs updates\n\n## Testing\n- export DATABASE_URL=postgresql://pfa:pfa_dev_password_change_me@127.0.0.1:5432/pfa && make test-backend\n- cd frontend && npm install && npm run test && npm run build && npm run lint\n\nCloses #27