### PR TITLE
feat(slice-6): statement storage lifecycle — list + purge UI

### DIFF
--- a/backend/pfa/ingest_jobs.py
+++ b/backend/pfa/ingest_jobs.py
@@ -378,8 +378,10 @@ def retry_job(job_id: UUID) -> None:
 
 
 def recoverable_job_ids() -> list[UUID]:
+    statuses = tuple(ACTIVE_STATUSES)
     with connect() as conn:
         rows = conn.execute(
-            "SELECT id FROM ingest_jobs WHERE status IN ('pending', 'running')"
+            "SELECT id FROM ingest_jobs WHERE status = ANY(%s)",
+            (list(statuses),),
         ).fetchall()
     return [UUID(str(row[0])) for row in rows]

--- a/backend/pfa/main.py
+++ b/backend/pfa/main.py
@@ -14,6 +14,7 @@ from fastapi.responses import RedirectResponse
 from pydantic import BaseModel
 
 from pfa.anomalies_api import router as anomalies_router
+from pfa.statements_api import router as statements_router
 from pfa.auth import require_authenticated
 from pfa.auth_api import router as auth_router
 from pfa.budget_api import router as budget_router
@@ -81,6 +82,7 @@ app.include_router(
 app.include_router(recurring_router, dependencies=[Depends(require_authenticated)])
 app.include_router(chat_router, dependencies=[Depends(require_authenticated)])
 app.include_router(anomalies_router, dependencies=[Depends(require_authenticated)])
+app.include_router(statements_router, dependencies=[Depends(require_authenticated)])
 
 
 @app.get("/", include_in_schema=False)

--- a/backend/pfa/schema.sql
+++ b/backend/pfa/schema.sql
@@ -53,7 +53,8 @@ CREATE TABLE IF NOT EXISTS ingest_jobs (
 CREATE INDEX IF NOT EXISTS idx_ingest_jobs_status_created_at
   ON ingest_jobs(status, created_at DESC);
 
--- Idempotent column addition for DBs created before slice 5 job support.
+-- Idempotent column addition: ensures DBs provisioned before this column was
+-- added to the CREATE TABLE above receive it on next schema migration run.
 ALTER TABLE ingest_jobs
   ADD COLUMN IF NOT EXISTS statement_id UUID;
 

--- a/backend/pfa/statements_api.py
+++ b/backend/pfa/statements_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import datetime
 from uuid import UUID
 
 from fastapi import APIRouter, HTTPException
@@ -21,7 +22,7 @@ class StatementOut(BaseModel):
     byte_size: int
     inserted: int
     skipped_duplicates: int
-    created_at: str
+    created_at: datetime
 
 
 def _row_to_out(row: dict) -> StatementOut:
@@ -33,7 +34,7 @@ def _row_to_out(row: dict) -> StatementOut:
         byte_size=row["byte_size"],
         inserted=row["inserted"],
         skipped_duplicates=row["skipped_duplicates"],
-        created_at=row["created_at"].isoformat(),
+        created_at=row["created_at"],
     )
 
 

--- a/backend/pfa/statements_api.py
+++ b/backend/pfa/statements_api.py
@@ -1,0 +1,83 @@
+"""HTTP routes for statement listing and detail (Slice 6)."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException
+from psycopg.rows import dict_row
+from pydantic import BaseModel
+
+from pfa.db import connect
+
+router = APIRouter(tags=["statements"])
+
+
+class StatementOut(BaseModel):
+    id: UUID
+    account_id: UUID
+    filename: str
+    sha256: str
+    byte_size: int
+    inserted: int
+    skipped_duplicates: int
+    created_at: str
+
+
+def _row_to_out(row: dict) -> StatementOut:
+    return StatementOut(
+        id=row["id"],
+        account_id=row["account_id"],
+        filename=row["filename"],
+        sha256=row["sha256"],
+        byte_size=row["byte_size"],
+        inserted=row["inserted"],
+        skipped_duplicates=row["skipped_duplicates"],
+        created_at=row["created_at"].isoformat(),
+    )
+
+
+@router.get("/statements", response_model=list[StatementOut])
+def list_statements(account_id: UUID | None = None):
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            if account_id is not None:
+                cur.execute(
+                    """
+                    SELECT id, account_id, filename, sha256, byte_size,
+                           inserted, skipped_duplicates, created_at
+                    FROM statements
+                    WHERE account_id = %s
+                    ORDER BY created_at DESC
+                    """,
+                    (str(account_id),),
+                )
+            else:
+                cur.execute(
+                    """
+                    SELECT id, account_id, filename, sha256, byte_size,
+                           inserted, skipped_duplicates, created_at
+                    FROM statements
+                    ORDER BY created_at DESC
+                    """
+                )
+            return [_row_to_out(row) for row in cur.fetchall()]
+
+
+@router.get("/statements/{statement_id}", response_model=StatementOut)
+def get_statement(statement_id: UUID):
+    with connect() as conn:
+        with conn.cursor(row_factory=dict_row) as cur:
+            cur.execute(
+                """
+                SELECT id, account_id, filename, sha256, byte_size,
+                       inserted, skipped_duplicates, created_at
+                FROM statements
+                WHERE id = %s
+                """,
+                (str(statement_id),),
+            )
+            row = cur.fetchone()
+    if row is None:
+        raise HTTPException(status_code=404, detail="statement not found")
+    return _row_to_out(row)

--- a/backend/tests/test_statement_lifecycle.py
+++ b/backend/tests/test_statement_lifecycle.py
@@ -1,0 +1,81 @@
+"""Statement listing and lifecycle tests (Slice 6)."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+_CSV = (
+    "transaction_date,amount,description\n"
+    "2025-01-01,-10.00,COFFEE\n"
+    "2025-01-02,500.00,PAYROLL\n"
+).encode()
+
+
+def _upload(client, account_id, csv_bytes=None, filename="test.csv"):
+    return client.post(
+        "/ingest/csv",
+        data={"account_id": str(account_id)},
+        files={"file": (filename, csv_bytes or _CSV, "text/csv")},
+    )
+
+
+def test_list_statements_empty(client, sample_account_id, upload_dir):
+    r = client.get(f"/statements?account_id={sample_account_id}")
+    assert r.status_code == 200
+    assert r.json() == []
+
+
+def test_list_statements_after_ingest(client, sample_account_id, upload_dir):
+    ingest_r = _upload(client, sample_account_id, filename="bank.csv")
+    assert ingest_r.status_code == 200
+    sid = ingest_r.json()["statement_id"]
+
+    r = client.get(f"/statements?account_id={sample_account_id}")
+    assert r.status_code == 200
+    items = r.json()
+    assert len(items) == 1
+
+    item = items[0]
+    assert item["id"] == sid
+    assert item["account_id"] == str(sample_account_id)
+    assert item["filename"] == "bank.csv"
+    assert "sha256" in item
+    assert item["inserted"] == 2
+    assert item["skipped_duplicates"] == 0
+    assert "byte_size" in item
+    assert "created_at" in item
+
+
+def test_get_statement_by_id(client, sample_account_id, upload_dir):
+    ingest_r = _upload(client, sample_account_id)
+    assert ingest_r.status_code == 200
+    sid = ingest_r.json()["statement_id"]
+
+    r = client.get(f"/statements/{sid}")
+    assert r.status_code == 200
+    item = r.json()
+    assert item["id"] == sid
+    assert item["account_id"] == str(sample_account_id)
+    assert "filename" in item
+    assert "sha256" in item
+
+
+def test_get_statement_not_found(client, upload_dir):
+    r = client.get(f"/statements/{uuid.uuid4()}")
+    assert r.status_code == 404
+
+
+def test_purge_statement_removes_it(client, sample_account_id, upload_dir):
+    ingest_r = _upload(client, sample_account_id)
+    assert ingest_r.status_code == 200
+    sid = ingest_r.json()["statement_id"]
+
+    del_r = client.delete(f"/statements/{sid}")
+    assert del_r.status_code == 204
+
+    r = client.get(f"/statements/{sid}")
+    assert r.status_code == 404

--- a/backend/tests/test_statement_lifecycle.py
+++ b/backend/tests/test_statement_lifecycle.py
@@ -74,8 +74,12 @@ def test_purge_statement_removes_it(client, sample_account_id, upload_dir):
     assert ingest_r.status_code == 200
     sid = ingest_r.json()["statement_id"]
 
+    uploaded_files = [path for path in upload_dir.rglob("*") if path.is_file()]
+    assert uploaded_files, "expected uploaded raw bytes to be stored in upload_dir"
+
     del_r = client.delete(f"/statements/{sid}")
     assert del_r.status_code == 204
 
     r = client.get(f"/statements/{sid}")
     assert r.status_code == 404
+    assert not any(path.is_file() for path in upload_dir.rglob("*"))

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -29,6 +29,9 @@
         "typescript-eslint": "^8.58.2",
         "vite": "^8.0.10",
         "vitest": "^4.1.5"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -910,9 +913,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -930,9 +930,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -950,9 +947,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -970,9 +964,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -990,9 +981,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1010,9 +998,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2747,9 +2732,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2771,9 +2753,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2795,9 +2774,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2819,9 +2795,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -179,3 +179,45 @@ code {
     grid-template-columns: 1fr;
   }
 }
+
+.danger-button {
+  background: #dc2626;
+  color: #fff;
+  border: none;
+  border-radius: 8px;
+  padding: 0.4rem 0.9rem;
+  font-size: 0.875rem;
+  cursor: pointer;
+}
+.danger-button:hover:not(:disabled) { background: #b91c1c; }
+.danger-button:disabled { opacity: 0.6; cursor: not-allowed; }
+
+.empty-state {
+  color: #94a3b8;
+  font-style: italic;
+  margin-top: 1rem;
+}
+
+.statements-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  font-size: 0.9rem;
+}
+.statements-table th,
+.statements-table td {
+  text-align: left;
+  padding: 0.5rem 0.75rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+.statements-table th { color: #94a3b8; font-weight: 600; }
+
+.confirm-inline {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+.confirm-text {
+  font-size: 0.8rem;
+  color: #fbbf24;
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -170,6 +170,7 @@ function Shell({
           <Route path="/" element={<Overview username={username} protectedState={protectedState} />} />
           <Route path="/smoke" element={<SmokePage protectedState={protectedState} />} />
           <Route path="/statements" element={<StatementsPage />} />
+          <Route path="/statements/:id" element={<StatementsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -170,7 +170,7 @@ function Shell({
           <Route path="/" element={<Overview username={username} protectedState={protectedState} />} />
           <Route path="/smoke" element={<SmokePage protectedState={protectedState} />} />
           <Route path="/statements" element={<StatementsPage />} />
-          <Route path="/statements/:id" element={<StatementsPage />} />
+          <Route path="/statements/:id" element={<Navigate to="/statements" replace />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react'
 import type { FormEvent } from 'react'
 import { BrowserRouter, Link, Navigate, Route, Routes } from 'react-router-dom'
 import { getSession, listCategories, login, logout, type SessionState } from './api'
+import StatementsPage from './StatementsPage'
 import './App.css'
 
 type ProtectedState =
@@ -163,10 +164,12 @@ function Shell({
         <nav className="shell-nav">
           <Link to="/">Overview</Link>
           <Link to="/smoke">API smoke</Link>
+          <Link to="/statements">Statements</Link>
         </nav>
         <Routes>
           <Route path="/" element={<Overview username={username} protectedState={protectedState} />} />
           <Route path="/smoke" element={<SmokePage protectedState={protectedState} />} />
+          <Route path="/statements" element={<StatementsPage />} />
           <Route path="*" element={<Navigate to="/" replace />} />
         </Routes>
       </div>

--- a/frontend/src/StatementsPage.test.tsx
+++ b/frontend/src/StatementsPage.test.tsx
@@ -1,0 +1,157 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import StatementsPage from './StatementsPage'
+
+// StatementsPage calls listStatements() then listAccounts() in Promise.all.
+// fetch mock calls are consumed in the order the underlying fetch() calls fire,
+// which is: GET /api/statements first, GET /api/accounts second.
+
+const ACCOUNT = { id: 'acct-1', institution_id: 'inst-1', name: 'Checking', currency: 'USD' }
+const STATEMENT = {
+  id: 'stmt-1',
+  account_id: 'acct-1',
+  filename: 'jan.csv',
+  sha256: 'abc123',
+  byte_size: 2048,
+  inserted: 3,
+  skipped_duplicates: 1,
+  created_at: '2025-01-15T10:00:00',
+}
+
+function mockFetch(responses: Array<{ ok?: boolean; status?: number; body?: unknown }>) {
+  const mock = vi.fn()
+  for (const r of responses) {
+    mock.mockResolvedValueOnce({
+      ok: r.ok ?? true,
+      status: r.status ?? 200,
+      json: async () => r.body,
+    })
+  }
+  vi.stubGlobal('fetch', mock)
+  return mock
+}
+
+describe('StatementsPage', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    cleanup()
+  })
+
+  it('shows loading state while fetching', async () => {
+    // Never resolves so the loading indicator stays visible.
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})))
+    render(<StatementsPage />)
+    expect(screen.getByText(/loading statements/i)).toBeInTheDocument()
+  })
+
+  it('shows empty state when there are no statements', async () => {
+    mockFetch([
+      { body: [] }, // listStatements
+      { body: [] }, // listAccounts
+    ])
+    render(<StatementsPage />)
+    expect(await screen.findByText(/no statements uploaded yet/i)).toBeInTheDocument()
+  })
+
+  it('renders the statement list with account name', async () => {
+    mockFetch([
+      { body: [STATEMENT] }, // listStatements
+      { body: [ACCOUNT] },   // listAccounts
+    ])
+    render(<StatementsPage />)
+
+    // Account name appears in the Account column.
+    expect(await screen.findByText('Checking')).toBeInTheDocument()
+    // Filename appears.
+    expect(screen.getByText('jan.csv')).toBeInTheDocument()
+    // Inserted / skipped counts.
+    expect(screen.getByText('3')).toBeInTheDocument()
+    expect(screen.getByText('1')).toBeInTheDocument()
+    // Purge button is visible.
+    expect(screen.getByRole('button', { name: /purge/i })).toBeInTheDocument()
+  })
+
+  it('falls back to account_id when account is not in the accounts list', async () => {
+    mockFetch([
+      { body: [STATEMENT] }, // listStatements
+      { body: [] },          // listAccounts — empty, so name unknown
+    ])
+    render(<StatementsPage />)
+    expect(await screen.findByText('acct-1')).toBeInTheDocument()
+  })
+
+  it('shows inline confirmation when Purge is clicked', async () => {
+    mockFetch([
+      { body: [STATEMENT] },
+      { body: [ACCOUNT] },
+    ])
+    render(<StatementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /purge/i }))
+
+    expect(screen.getByText(/are you sure/i)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /yes, delete/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /cancel/i })).toBeInTheDocument()
+  })
+
+  it('cancel dismisses the confirmation without deleting', async () => {
+    mockFetch([
+      { body: [STATEMENT] },
+      { body: [ACCOUNT] },
+    ])
+    render(<StatementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /purge/i }))
+    expect(screen.getByRole('button', { name: /yes, delete/i })).toBeInTheDocument()
+
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+
+    await waitFor(() => {
+      expect(screen.queryByText(/are you sure/i)).not.toBeInTheDocument()
+    })
+    // Row should still be present.
+    expect(screen.getByText('jan.csv')).toBeInTheDocument()
+  })
+
+  it('shows success banner and removes row after successful purge', async () => {
+    mockFetch([
+      { body: [STATEMENT] },    // listStatements
+      { body: [ACCOUNT] },      // listAccounts
+      { status: 204, body: undefined }, // DELETE
+    ])
+    render(<StatementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /purge/i }))
+    fireEvent.click(screen.getByRole('button', { name: /yes, delete/i }))
+
+    expect(await screen.findByText(/statement removed from the app/i)).toBeInTheDocument()
+    expect(screen.queryByText('jan.csv')).not.toBeInTheDocument()
+  })
+
+  it('shows error banner when purge fails', async () => {
+    mockFetch([
+      { body: [STATEMENT] },    // listStatements
+      { body: [ACCOUNT] },      // listAccounts
+      { ok: false, status: 500, body: { detail: 'internal server error' } }, // DELETE
+    ])
+    render(<StatementsPage />)
+
+    fireEvent.click(await screen.findByRole('button', { name: /purge/i }))
+    fireEvent.click(screen.getByRole('button', { name: /yes, delete/i }))
+
+    expect(await screen.findByText(/internal server error/i)).toBeInTheDocument()
+    // Row should still be present.
+    expect(screen.getByText('jan.csv')).toBeInTheDocument()
+  })
+
+  it('shows error banner when loading statements fails', async () => {
+    const mock = vi.fn().mockRejectedValue(new Error('network failure'))
+    vi.stubGlobal('fetch', mock)
+    render(<StatementsPage />)
+    // The banner renders the Error's message directly; the 'Failed to load statements'
+    // fallback only fires for non-Error throws.
+    expect(await screen.findByText(/network failure/i)).toBeInTheDocument()
+    expect(screen.getByText(/network failure/i).closest('p')).toHaveClass('error-banner')
+  })
+})

--- a/frontend/src/StatementsPage.test.tsx
+++ b/frontend/src/StatementsPage.test.tsx
@@ -3,10 +3,8 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import StatementsPage from './StatementsPage'
 
-// StatementsPage calls listStatements() then listAccounts() in Promise.all.
-// fetch mock calls are consumed in the order the underlying fetch() calls fire,
-// which is: GET /api/statements first, GET /api/accounts second.
-
+// Fetch mock order: GET /api/statements, GET /api/accounts, GET /api/institutions
+const INSTITUTION = { id: 'inst-1', name: 'First Bank' }
 const ACCOUNT = { id: 'acct-1', institution_id: 'inst-1', name: 'Checking', currency: 'USD' }
 const STATEMENT = {
   id: 'stmt-1',
@@ -49,20 +47,22 @@ describe('StatementsPage', () => {
     mockFetch([
       { body: [] }, // listStatements
       { body: [] }, // listAccounts
+      { body: [] }, // listInstitutions
     ])
     render(<StatementsPage />)
     expect(await screen.findByText(/no statements uploaded yet/i)).toBeInTheDocument()
   })
 
-  it('renders the statement list with account name', async () => {
+  it('renders the statement list with institution and account name', async () => {
     mockFetch([
-      { body: [STATEMENT] }, // listStatements
-      { body: [ACCOUNT] },   // listAccounts
+      { body: [STATEMENT] },    // listStatements
+      { body: [ACCOUNT] },      // listAccounts
+      { body: [INSTITUTION] },  // listInstitutions
     ])
     render(<StatementsPage />)
 
-    // Account name appears in the Account column.
-    expect(await screen.findByText('Checking')).toBeInTheDocument()
+    // Full "Institution — Account" label is shown.
+    expect(await screen.findByText('First Bank — Checking')).toBeInTheDocument()
     // Filename appears.
     expect(screen.getByText('jan.csv')).toBeInTheDocument()
     // Inserted / skipped counts.
@@ -72,10 +72,21 @@ describe('StatementsPage', () => {
     expect(screen.getByRole('button', { name: /purge/i })).toBeInTheDocument()
   })
 
+  it('shows only account name when institution is not found', async () => {
+    mockFetch([
+      { body: [STATEMENT] },
+      { body: [ACCOUNT] },
+      { body: [] }, // no institutions
+    ])
+    render(<StatementsPage />)
+    expect(await screen.findByText('Checking')).toBeInTheDocument()
+  })
+
   it('falls back to account_id when account is not in the accounts list', async () => {
     mockFetch([
-      { body: [STATEMENT] }, // listStatements
-      { body: [] },          // listAccounts — empty, so name unknown
+      { body: [STATEMENT] },
+      { body: [] }, // listAccounts — empty
+      { body: [] }, // listInstitutions
     ])
     render(<StatementsPage />)
     expect(await screen.findByText('acct-1')).toBeInTheDocument()
@@ -85,6 +96,7 @@ describe('StatementsPage', () => {
     mockFetch([
       { body: [STATEMENT] },
       { body: [ACCOUNT] },
+      { body: [INSTITUTION] },
     ])
     render(<StatementsPage />)
 
@@ -99,6 +111,7 @@ describe('StatementsPage', () => {
     mockFetch([
       { body: [STATEMENT] },
       { body: [ACCOUNT] },
+      { body: [INSTITUTION] },
     ])
     render(<StatementsPage />)
 
@@ -116,8 +129,9 @@ describe('StatementsPage', () => {
 
   it('shows success banner and removes row after successful purge', async () => {
     mockFetch([
-      { body: [STATEMENT] },    // listStatements
-      { body: [ACCOUNT] },      // listAccounts
+      { body: [STATEMENT] },
+      { body: [ACCOUNT] },
+      { body: [INSTITUTION] },
       { status: 204, body: undefined }, // DELETE
     ])
     render(<StatementsPage />)
@@ -131,8 +145,9 @@ describe('StatementsPage', () => {
 
   it('shows error banner when purge fails', async () => {
     mockFetch([
-      { body: [STATEMENT] },    // listStatements
-      { body: [ACCOUNT] },      // listAccounts
+      { body: [STATEMENT] },
+      { body: [ACCOUNT] },
+      { body: [INSTITUTION] },
       { ok: false, status: 500, body: { detail: 'internal server error' } }, // DELETE
     ])
     render(<StatementsPage />)
@@ -155,3 +170,4 @@ describe('StatementsPage', () => {
     expect(screen.getByText(/network failure/i).closest('p')).toHaveClass('error-banner')
   })
 })
+

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { listAccounts, listStatements, purgeStatement, type Account, type Statement } from './api'
+import { listAccounts, listInstitutions, listStatements, purgeStatement, type Account, type Institution, type Statement } from './api'
 
 type Banner = { type: 'success' | 'error'; message: string }
 
@@ -16,6 +16,7 @@ function formatDate(iso: string): string {
 export default function StatementsPage() {
   const [statements, setStatements] = useState<Statement[]>([])
   const [accounts, setAccounts] = useState<Map<string, Account>>(new Map())
+  const [institutions, setInstitutions] = useState<Map<string, Institution>>(new Map())
   const [loading, setLoading] = useState(true)
   const [banner, setBanner] = useState<Banner | null>(null)
   const [confirmId, setConfirmId] = useState<string | null>(null)
@@ -28,10 +29,12 @@ export default function StatementsPage() {
       setStatements(data)
 
       try {
-        const acctList = await listAccounts()
+        const [acctList, instList] = await Promise.all([listAccounts(), listInstitutions()])
         setAccounts(new Map(acctList.map(a => [a.id, a])))
+        setInstitutions(new Map(instList.map(i => [i.id, i])))
       } catch {
         setAccounts(new Map())
+        setInstitutions(new Map())
       }
     } catch (err) {
       setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to load statements' })
@@ -87,7 +90,14 @@ export default function StatementsPage() {
           <tbody>
             {statements.map(s => (
               <tr key={s.id}>
-                <td>{accounts.get(s.account_id)?.name ?? s.account_id}</td>
+                <td>
+                  {(() => {
+                    const acct = accounts.get(s.account_id)
+                    if (!acct) return s.account_id
+                    const inst = institutions.get(acct.institution_id)
+                    return inst ? `${inst.name} — ${acct.name}` : acct.name
+                  })()}
+                </td>
                 <td>{s.filename}</td>
                 <td>{formatDate(s.created_at)}</td>
                 <td>{formatBytes(s.byte_size)}</td>

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { listStatements, purgeStatement, type Statement } from './api'
+import { listAccounts, listStatements, purgeStatement, type Account, type Statement } from './api'
 
 type Banner = { type: 'success' | 'error'; message: string }
 
@@ -15,6 +15,7 @@ function formatDate(iso: string): string {
 
 export default function StatementsPage() {
   const [statements, setStatements] = useState<Statement[]>([])
+  const [accounts, setAccounts] = useState<Map<string, Account>>(new Map())
   const [loading, setLoading] = useState(true)
   const [banner, setBanner] = useState<Banner | null>(null)
   const [confirmId, setConfirmId] = useState<string | null>(null)
@@ -23,8 +24,9 @@ export default function StatementsPage() {
   async function load() {
     setLoading(true)
     try {
-      const data = await listStatements()
+      const [data, acctList] = await Promise.all([listStatements(), listAccounts()])
       setStatements(data)
+      setAccounts(new Map(acctList.map(a => [a.id, a])))
     } catch (err) {
       setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to load statements' })
     } finally {
@@ -67,6 +69,7 @@ export default function StatementsPage() {
         <table className="statements-table">
           <thead>
             <tr>
+              <th>Account</th>
               <th>Filename</th>
               <th>Uploaded</th>
               <th>Size</th>
@@ -78,6 +81,7 @@ export default function StatementsPage() {
           <tbody>
             {statements.map(s => (
               <tr key={s.id}>
+                <td>{accounts.get(s.account_id)?.name ?? s.account_id}</td>
                 <td>{s.filename}</td>
                 <td>{formatDate(s.created_at)}</td>
                 <td>{formatBytes(s.byte_size)}</td>

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react'
+import { listStatements, purgeStatement, type Statement } from './api'
+
+type Banner = { type: 'success' | 'error'; message: string }
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString()
+}
+
+export default function StatementsPage() {
+  const [statements, setStatements] = useState<Statement[]>([])
+  const [loading, setLoading] = useState(true)
+  const [banner, setBanner] = useState<Banner | null>(null)
+  const [confirmId, setConfirmId] = useState<string | null>(null)
+  const [purging, setPurging] = useState(false)
+
+  async function load() {
+    setLoading(true)
+    try {
+      const data = await listStatements()
+      setStatements(data)
+    } catch (err) {
+      setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to load statements' })
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => { void load() }, [])
+
+  async function handlePurge(id: string) {
+    setPurging(true)
+    setBanner(null)
+    try {
+      await purgeStatement(id)
+      setStatements(prev => prev.filter(s => s.id !== id))
+      setBanner({ type: 'success', message: 'Statement and its transactions permanently deleted.' })
+    } catch (err) {
+      setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Purge failed' })
+    } finally {
+      setPurging(false)
+      setConfirmId(null)
+    }
+  }
+
+  return (
+    <section className="panel">
+      <h2>Statements</h2>
+
+      {banner ? (
+        <p className={banner.type === 'success' ? 'success-banner' : 'error-banner'}>
+          {banner.message}
+        </p>
+      ) : null}
+
+      {loading ? (
+        <p>Loading statements…</p>
+      ) : statements.length === 0 ? (
+        <p className="empty-state">No statements uploaded yet.</p>
+      ) : (
+        <table className="statements-table">
+          <thead>
+            <tr>
+              <th>Filename</th>
+              <th>Uploaded</th>
+              <th>Size</th>
+              <th>Inserted</th>
+              <th>Skipped</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {statements.map(s => (
+              <tr key={s.id}>
+                <td>{s.filename}</td>
+                <td>{formatDate(s.created_at)}</td>
+                <td>{formatBytes(s.byte_size)}</td>
+                <td>{s.inserted}</td>
+                <td>{s.skipped_duplicates}</td>
+                <td>
+                  {confirmId === s.id ? (
+                    <span className="confirm-inline">
+                      <span className="confirm-text">
+                        Are you sure? This permanently deletes the file and all transactions from this statement.
+                      </span>
+                      <button
+                        type="button"
+                        className="danger-button"
+                        disabled={purging}
+                        onClick={() => void handlePurge(s.id)}
+                      >
+                        {purging ? 'Deleting…' : 'Yes, delete'}
+                      </button>
+                      <button
+                        type="button"
+                        className="secondary-button"
+                        disabled={purging}
+                        onClick={() => setConfirmId(null)}
+                      >
+                        Cancel
+                      </button>
+                    </span>
+                  ) : (
+                    <button
+                      type="button"
+                      className="danger-button"
+                      onClick={() => setConfirmId(s.id)}
+                    >
+                      Purge
+                    </button>
+                  )}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </section>
+  )
+}

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -42,7 +42,7 @@ export default function StatementsPage() {
     try {
       await purgeStatement(id)
       setStatements(prev => prev.filter(s => s.id !== id))
-      setBanner({ type: 'success', message: 'Statement removed from the app. Associated file cleanup may complete separately.' })
+      setBanner({ type: 'success', message: 'Statement removed from the app. This operation does not confirm that any underlying uploaded file bytes were deleted.' })
     } catch (err) {
       setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Purge failed' })
     } finally {

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -24,9 +24,15 @@ export default function StatementsPage() {
   async function load() {
     setLoading(true)
     try {
-      const [data, acctList] = await Promise.all([listStatements(), listAccounts()])
+      const data = await listStatements()
       setStatements(data)
-      setAccounts(new Map(acctList.map(a => [a.id, a])))
+
+      try {
+        const acctList = await listAccounts()
+        setAccounts(new Map(acctList.map(a => [a.id, a])))
+      } catch {
+        setAccounts(new Map())
+      }
     } catch (err) {
       setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Failed to load statements' })
     } finally {

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -40,7 +40,7 @@ export default function StatementsPage() {
     try {
       await purgeStatement(id)
       setStatements(prev => prev.filter(s => s.id !== id))
-      setBanner({ type: 'success', message: 'Statement and its transactions permanently deleted.' })
+      setBanner({ type: 'success', message: 'Statement removed from the app. Associated file cleanup may complete separately.' })
     } catch (err) {
       setBanner({ type: 'error', message: err instanceof Error ? err.message : 'Purge failed' })
     } finally {

--- a/frontend/src/StatementsPage.tsx
+++ b/frontend/src/StatementsPage.tsx
@@ -75,7 +75,7 @@ export default function StatementsPage() {
               <th>Size</th>
               <th>Inserted</th>
               <th>Skipped</th>
-              <th></th>
+              <th scope="col">Actions</th>
             </tr>
           </thead>
           <tbody>

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -20,6 +20,11 @@ export type Statement = {
   created_at: string
 }
 
+export type Institution = {
+  id: string
+  name: string
+}
+
 export type Account = {
   id: string
   institution_id: string
@@ -96,4 +101,8 @@ export function purgeStatement(id: string): Promise<void> {
 
 export function listAccounts(): Promise<Account[]> {
   return request<Account[]>('/accounts')
+}
+
+export function listInstitutions(): Promise<Institution[]> {
+  return request<Institution[]>('/institutions')
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -9,6 +9,24 @@ export type Category = {
   name: string
 }
 
+export type Statement = {
+  id: string
+  account_id: string
+  filename: string
+  sha256: string
+  byte_size: number
+  inserted: number
+  skipped_duplicates: number
+  created_at: string
+}
+
+export type Account = {
+  id: string
+  institution_id: string
+  name: string
+  currency: string
+}
+
 type RequestOptions = Omit<RequestInit, 'credentials'> & {
   bodyJson?: unknown
 }
@@ -61,4 +79,21 @@ export function logout(): Promise<void> {
 
 export function listCategories(): Promise<Category[]> {
   return request<Category[]>('/categories')
+}
+
+export function listStatements(accountId?: string): Promise<Statement[]> {
+  const qs = accountId ? `?account_id=${accountId}` : ''
+  return request<Statement[]>(`/statements${qs}`)
+}
+
+export function getStatement(id: string): Promise<Statement> {
+  return request<Statement>(`/statements/${id}`)
+}
+
+export function purgeStatement(id: string): Promise<void> {
+  return request<void>(`/statements/${id}`, { method: 'DELETE' })
+}
+
+export function listAccounts(): Promise<Account[]> {
+  return request<Account[]>('/accounts')
 }


### PR DESCRIPTION
Implements Slice 6: adds GET /statements and GET /statements/{id} endpoints, statement list page with purge confirmation, wired into the app shell nav.

Closes #7